### PR TITLE
fix: path to build.js

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -5,7 +5,7 @@ branding:
   color: green
 runs:
   using: node20
-  main: dist/build.js
+  main: ../dist/build.js
 
 # All inputs are also supported in GitLab CI, input as an all-uppercase variable.
 inputs:


### PR DESCRIPTION
This is a small patch that updates the path used by the build script to fix a file-not-found error.

While trying out the [push example](https://github.com/stainless-api/upload-openapi-spec-action/blob/main/examples/push.yml), I encountered the following error:

```
[build](https://github.com/erikpilz/stainless-push-demo/actions/runs/16240675214/job/45856641038#step:3:18)
File not found: '/home/runner/work/_actions/stainless-api/upload-openapi-spec-action/v1/build/dist/build.js'
```

This change resolves that issue and allows the example to run as expected.