### PR TITLE
for build.yml action, do not create builds if there's no change

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -49,6 +49,7 @@ async function main() {
       configContent: config.config,
       guessConfig,
       commitMessage,
+      allowEmpty: false,
     })) {
       lastValue = value;
     }
@@ -82,8 +83,16 @@ async function main() {
       console.error("No documented spec found.");
     }
   } catch (error) {
-    console.error("Error interacting with API:", error);
-    process.exit(1);
+    if (
+      error instanceof Stainless.BadRequestError &&
+      error.message.includes("No changes to commit")
+    ) {
+      console.log("No changes to commit, skipping build.");
+      process.exit(0);
+    } else {
+      console.error("Error interacting with API:", error);
+      process.exit(1);
+    }
   }
 }
 

--- a/src/runBuilds.ts
+++ b/src/runBuilds.ts
@@ -38,6 +38,7 @@ export async function* runBuilds({
   configContent,
   guessConfig = false,
   commitMessage,
+  allowEmpty = true,
 }: {
   stainless: Stainless;
   projectName: string;
@@ -49,6 +50,7 @@ export async function* runBuilds({
   configContent?: string;
   guessConfig?: boolean;
   commitMessage?: string;
+  allowEmpty?: boolean;
 }): AsyncGenerator<RunResult> {
   if (mergeBranch && (oasContent || configContent)) {
     throw new Error(
@@ -90,7 +92,7 @@ export async function* runBuilds({
             },
         branch,
         commit_message: commitMessage,
-        allow_empty: true,
+        allow_empty: allowEmpty,
       },
       {
         // For very large specs, writing the config files can take a while.


### PR DESCRIPTION
for the build action, there's no reason to create a build if neither the spec or config has changed - we should instead not allow an empty change, catch the 400, and display a message in the action output