### PR TITLE
fix: improve comment format

### DIFF
--- a/dist/merge.js
+++ b/dist/merge.js
@@ -32955,8 +32955,8 @@ function Result({
     body: [
       Description,
       StatusLine(base, head),
-      base ? DiagnosticsDetails(head, base) : null,
-      InstallationDetails(head, lang)
+      InstallationDetails(head, lang),
+      base ? DiagnosticsDetails(head, base) : null
     ].filter((value) => Boolean(value)).join("\n"),
     open: category !== "success" && category !== "pending"
   });
@@ -32978,9 +32978,9 @@ function ResultIcon(category) {
 function StatusLine(base, head) {
   return [
     StatusStep(base, head, "generate"),
+    StatusStep(base, head, "build"),
     StatusStep(base, head, "lint"),
-    StatusStep(base, head, "test"),
-    StatusStep(base, head, "build")
+    StatusStep(base, head, "test")
   ].filter((value) => Boolean(value)).join(` ${Symbol2.RightwardsArrow} `);
 }
 function StatusStep(base, head, step) {
@@ -33069,6 +33069,7 @@ function MergeConflictLink(outcome) {
     href: `https://github.com/${owner}/${name}/pull/${number}`
   });
 }
+var diagnosticLevels = ["fatal", "error", "warning", "note"];
 function DiagnosticsDetails(head, base) {
   if (!base.diagnostics || !head.diagnostics) return null;
   const newDiagnostics = head.diagnostics.filter(
@@ -33087,12 +33088,9 @@ function DiagnosticsDetails(head, base) {
     levelCounts[d.level]++;
   }
   const diagnosticCounts = Object.entries(levelCounts).filter(([, count]) => count > 0).map(([level, count]) => `${count} ${level}`);
-  const diagnosticList = newDiagnostics.slice(0, 10).map((d) => {
-    if (d.level === "note") {
-      return null;
-    }
-    return `${DiagnosticIcon[d.level]} ${Bold(d.code)}: ${d.message}`;
-  }).filter(Boolean);
+  const diagnosticList = newDiagnostics.sort(
+    (a, b) => diagnosticLevels.indexOf(a.level) - diagnosticLevels.indexOf(b.level)
+  ).slice(0, 10).map((d) => `${DiagnosticIcon[d.level]} ${Bold(d.code)}: ${d.message}`).filter(Boolean);
   const tableRows = diagnosticList.map((diagnostic) => `<tr>
 <td>${diagnostic}</td>
 </tr>`).join("\n");
@@ -33131,11 +33129,7 @@ function InstallationDetails(head, lang) {
       return null;
     }
   }
-  return Details({
-    summary: "Installation",
-    body: CodeBlock({ content: installation, language: "bash" }),
-    indent: false
-  });
+  return CodeBlock({ content: installation, language: "bash" });
 }
 function categorize(head, base) {
   if (head.commit?.status !== "completed") {

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -32953,8 +32953,8 @@ function Result({
     body: [
       Description,
       StatusLine(base, head),
-      base ? DiagnosticsDetails(head, base) : null,
-      InstallationDetails(head, lang)
+      InstallationDetails(head, lang),
+      base ? DiagnosticsDetails(head, base) : null
     ].filter((value) => Boolean(value)).join("\n"),
     open: category !== "success" && category !== "pending"
   });
@@ -32976,9 +32976,9 @@ function ResultIcon(category) {
 function StatusLine(base, head) {
   return [
     StatusStep(base, head, "generate"),
+    StatusStep(base, head, "build"),
     StatusStep(base, head, "lint"),
-    StatusStep(base, head, "test"),
-    StatusStep(base, head, "build")
+    StatusStep(base, head, "test")
   ].filter((value) => Boolean(value)).join(` ${Symbol2.RightwardsArrow} `);
 }
 function StatusStep(base, head, step) {
@@ -33067,6 +33067,7 @@ function MergeConflictLink(outcome) {
     href: `https://github.com/${owner}/${name}/pull/${number}`
   });
 }
+var diagnosticLevels = ["fatal", "error", "warning", "note"];
 function DiagnosticsDetails(head, base) {
   if (!base.diagnostics || !head.diagnostics) return null;
   const newDiagnostics = head.diagnostics.filter(
@@ -33085,12 +33086,9 @@ function DiagnosticsDetails(head, base) {
     levelCounts[d.level]++;
   }
   const diagnosticCounts = Object.entries(levelCounts).filter(([, count]) => count > 0).map(([level, count]) => `${count} ${level}`);
-  const diagnosticList = newDiagnostics.slice(0, 10).map((d) => {
-    if (d.level === "note") {
-      return null;
-    }
-    return `${DiagnosticIcon[d.level]} ${Bold(d.code)}: ${d.message}`;
-  }).filter(Boolean);
+  const diagnosticList = newDiagnostics.sort(
+    (a, b) => diagnosticLevels.indexOf(a.level) - diagnosticLevels.indexOf(b.level)
+  ).slice(0, 10).map((d) => `${DiagnosticIcon[d.level]} ${Bold(d.code)}: ${d.message}`).filter(Boolean);
   const tableRows = diagnosticList.map((diagnostic) => `<tr>
 <td>${diagnostic}</td>
 </tr>`).join("\n");
@@ -33129,11 +33127,7 @@ function InstallationDetails(head, lang) {
       return null;
     }
   }
-  return Details({
-    summary: "Installation",
-    body: CodeBlock({ content: installation, language: "bash" }),
-    indent: false
-  });
+  return CodeBlock({ content: installation, language: "bash" });
 }
 function categorize(head, base) {
   if (head.commit?.status !== "completed") {

--- a/src/__snapshots__/comment.test.ts.snap
+++ b/src/__snapshots__/comment.test.ts.snap
@@ -40,7 +40,10 @@ Edit this comment to update it.
 <blockquote>
 
 <i>There was a regression in your SDK.</i>
-<a href="https://github.com/test-org/test-sdk/actions/runs/210"><code>generate ✅</code></a> → <code>lint ⏳</code> → <a href="https://github.com/test-org/test-sdk/actions/runs/213"><code>test ✅</code></a> → <a href="https://github.com/test-org/test-sdk/actions/runs/211"><code>build ❗</code></a> (prev: <a href="https://github.com/test-org/test-sdk/actions/runs/200"><code>build ✅</code></a>)
+<a href="https://github.com/test-org/test-sdk/actions/runs/210"><code>generate ✅</code></a> → <a href="https://github.com/test-org/test-sdk/actions/runs/211"><code>build ❗</code></a> (prev: <a href="https://github.com/test-org/test-sdk/actions/runs/200"><code>build ✅</code></a>) → <code>lint ⏳</code> → <a href="https://github.com/test-org/test-sdk/actions/runs/213"><code>test ✅</code></a>
+\`\`\`bash
+npm install https://github.com/test-org/test-sdk.git#feature-branch
+\`\`\`
 <details>
 <summary>New diagnostics (1 error, 1 warning)</summary>
 
@@ -52,14 +55,6 @@ Edit this comment to update it.
 <td>⚠️ <b>Warning</b>: Other warning</td>
 </tr>
 </table>
-
-</details>
-<details>
-<summary>Installation</summary>
-
-\`\`\`bash
-npm install https://github.com/test-org/test-sdk.git#feature-branch
-\`\`\`
 
 </details>
 


### PR DESCRIPTION
* moves installation up and unnests it
* orders diagnostics and shows new note diagnostics
* reorders build, lint, test

snapshot looks like this:

---

<h3>✱ Stainless SDK previews</h3>

This PR will update the <code>test-project</code> SDKs with the following commit message.

```
Update API endpoints
```

Edit this comment to update it.

<details open>
<summary>❗ <b>test-project-python</b> <a href="https://app.stainless.com/test-org/test-project/studio?language=python&branch=feature-branch">studio</a></summary>

<blockquote>

<i>Code was not generated because there was a fatal error.</i>

</blockquote>

</details>

<details open>
<summary>⚡ <b>test-project-go</b> <a href="https://app.stainless.com/test-org/test-project/studio?language=go&branch=feature-branch">studio</a> · <a href="https://github.com/test-org/test-sdk/pull/1">conflict</a></summary>

<blockquote>

<i>There was a conflict between your custom code and your generated changes.</i>
<i>You don't need to resolve this conflict right now, but you will need to resolve it for your changes to be released to your users. Read more about why this happened <a href="https://www.stainless.com/docs/guides/add-custom-code">here</a>.</i>

</blockquote>

</details>

<details open>
<summary>⚠️ <b>test-project-typescript</b> <a href="https://app.stainless.com/test-org/test-project/studio?language=typescript&branch=feature-branch">studio</a> · <a href="https://github.com/test-org/test-sdk/tree/feature-branch">code</a> · <a href="https://github.com/test-org/test-sdk/compare/base-branch..feature-branch">diff</a></summary>

<blockquote>

<i>There was a regression in your SDK.</i>
<a href="https://github.com/test-org/test-sdk/actions/runs/210"><code>generate ✅</code></a> → <a href="https://github.com/test-org/test-sdk/actions/runs/211"><code>build ❗</code></a> (prev: <a href="https://github.com/test-org/test-sdk/actions/runs/200"><code>build ✅</code></a>) → <code>lint ⏳</code> → <a href="https://github.com/test-org/test-sdk/actions/runs/213"><code>test ✅</code></a>
```bash
npm install https://github.com/test-org/test-sdk.git#feature-branch
```
<details>
<summary>New diagnostics (1 error, 1 warning)</summary>

<table>
<tr>
<td>❗ <b>Error</b>: Error</td>
</tr>
<tr>
<td>⚠️ <b>Warning</b>: Other warning</td>
</tr>
</table>

</details>

</blockquote>

</details>

<details>
<summary>⏳ <b>test-project-java</b> <a href="https://app.stainless.com/test-org/test-project/studio?language=java&branch=feature-branch">studio</a> · <a href="https://github.com/test-org/test-sdk/tree/feature-branch">code</a></summary>

<blockquote>

<code>generate ✅</code> → <a href="https://github.com/test-org/test-sdk/actions/runs/213"><code>lint ✅</code></a> → <code>test ⏳</code>

</blockquote>

</details>

<details>
<summary>✅ <b>test-project-kotlin</b> <a href="https://app.stainless.com/test-org/test-project/studio?language=kotlin&branch=feature-branch">studio</a> · <a href="https://github.com/test-org/test-sdk/tree/feature-branch">code</a></summary>

<blockquote>

<i>Your SDK built successfully.</i>
<code>generate ✅</code> → <a href="https://github.com/test-org/test-sdk/actions/runs/213"><code>lint ✅</code></a> → <a href="https://github.com/test-org/test-sdk/actions/runs/214"><code>test ✅</code></a>

</blockquote>

</details>

⏳ These are partial results; builds are still running.

<hr />

<!-- stainless-preview-footer -->

<i>This comment is auto-generated by GitHub Actions and is automatically kept up to date as you push.<br/>Last updated: 2000-01-01 00:00:00 UTC</i>
