### PR TITLE
fix: filter by branch when finding base build

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -245,6 +245,7 @@ async function computeBranchFrom({
     const configCommit = (
       await stainless.builds.list({
         project: projectName,
+        branch: nonMainBaseRef ?? "main",
         revision: hashes,
         limit: 1,
       })


### PR DESCRIPTION
I think we really want the base build to come from the base ref, not a potentially-random other branch