### PR TITLE
fix: tweak categorizeOutcomes

### DIFF
--- a/src/outcomes.ts
+++ b/src/outcomes.ts
@@ -65,7 +65,7 @@ export function categorizeOutcome({
 } {
   const baseCommitConclusion = baseOutcome?.commit?.completed?.conclusion;
   const commitConclusion = outcome.commit?.completed?.conclusion;
-  const newNewCommitConclusion =
+  const netNewCommitConclusion =
     baseCommitConclusion !== commitConclusion ? commitConclusion : undefined;
 
   // If we have old diagnostics, only fail run against new diagnostics.
@@ -99,7 +99,7 @@ export function categorizeOutcome({
   }
 
   // Fatal reasons
-  if (!commitConclusion || newNewCommitConclusion === "fatal") {
+  if (!commitConclusion || netNewCommitConclusion === "fatal") {
     return {
       conclusion: "fatal",
       reason: "Code was not generated because there was a fatal error.",
@@ -149,7 +149,7 @@ export function categorizeOutcome({
       reason: "The build CI job failed.",
     };
   }
-  if (newNewCommitConclusion === "error") {
+  if (netNewCommitConclusion === "error") {
     return {
       conclusion: "error",
       reason: "Build had an error conclusion.",
@@ -175,13 +175,13 @@ export function categorizeOutcome({
       reason: "The test CI job failed.",
     };
   }
-  if (newNewCommitConclusion === "warning") {
+  if (netNewCommitConclusion === "warning") {
     return {
       conclusion: "warning",
       reason: "Build had a warning conclusion.",
     };
   }
-  if (newNewCommitConclusion === "merge_conflict") {
+  if (netNewCommitConclusion === "merge_conflict") {
     return {
       conclusion: "warning",
       reason:
@@ -197,7 +197,7 @@ export function categorizeOutcome({
       reason: `Found ${diagnosticCounts.note} note diagnostics.`,
     };
   }
-  if (newNewCommitConclusion === "note") {
+  if (netNewCommitConclusion === "note") {
     return {
       conclusion: "note",
       reason: "Build had a note conclusion.",


### PR DESCRIPTION
for timeouts and missing `commitConclusion` I think it makes sense to just return 'fatal' here - but for other conclusions (merge conflict, fatal error, error, warning, info), we should only consider net new conclusions,  since the desired behavior with preview builds is to only draw attention to new failures