### PR TITLE
docs: fix generated oas merge example

### DIFF
--- a/examples/pull_request_generated.yml
+++ b/examples/pull_request_generated.yml
@@ -88,6 +88,24 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Checkout base ref
+        uses: stainless-api/upload-openapi-spec-action/checkout-pr-ref@v1
+        with:
+          ref: base
+          oas_path: ${{ env.OAS_PATH }}
+          config_path: ${{ env.CONFIG_PATH }}
+
+      - name: Generate old OpenAPI spec
+        # Add a step that generates the OpenAPI spec, based on the checked-out
+        # repo contents, to the OAS_PATH.
+
+      - name: Checkout head ref
+        uses: stainless-api/upload-openapi-spec-action/checkout-pr-ref@v1
+        with:
+          ref: head
+          oas_path: ${{ env.OAS_PATH }}
+          config_path: ${{ env.CONFIG_PATH }}
+
       - name: Generate new OpenAPI spec
         # Add a step that generates the OpenAPI spec, based on the checked-out
         # repo contents, to the OAS_PATH.


### PR DESCRIPTION
in the `merge` step, as in the `preview` step, we need to generate both the old and the new spec so that the action is able to detect changes (see https://github.com/stainless-api/upload-openapi-spec-action/blame/d50c2fd955469b88089a2475b6ddd7995c7ebeea/src/merge.ts#L88-L98)