### PR TITLE
fix: refresh token in fetch if needed

### DIFF
--- a/dist/merge.js
+++ b/dist/merge.js
@@ -37701,11 +37701,14 @@ function getGitHostToken() {
 function getRunUrl() {
   return isGitLabCI() ? `${process.env.CI_PROJECT_URL}/-/pipelines/${process.env.CI_PIPELINE_ID}` : `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 }
-async function getStainlessAuthToken() {
+async function getStainlessAuth() {
   const apiKey = getInput("stainless_api_key", { required: isGitLabCI() });
   if (apiKey) {
     logger.debug("Authenticating with provided Stainless API key");
-    return apiKey;
+    return {
+      key: apiKey,
+      expiresAt: null
+    };
   }
   logger.debug("Authenticating with GitHub OIDC");
   const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
@@ -37726,7 +37729,10 @@ async function getStainlessAuthToken() {
     if (!data.value) {
       throw new Error("No token in OIDC response");
     }
-    return data.value;
+    return {
+      key: data.value,
+      expiresAt: Date.now() + 300 * 1e3
+    };
   } catch (error) {
     throw new Error(
       `Failed to authenticate with GitHub OIDC. Make sure your workflow has 'id-token: write' permission and that you have the Stainless GitHub App installed: https://www.stainless.com/docs/guides/publish/#install-the-stainless-github-app. Error: ${error}`
@@ -40804,6 +40810,21 @@ var package_default = {
 };
 
 // src/stainless.ts
+function createAutoRefreshFetch(initialAuth, refreshAuth) {
+  let currentApiKey = initialAuth.key;
+  let expiresAt = initialAuth.expiresAt;
+  return async (input, init) => {
+    if (expiresAt != null && expiresAt - Date.now() < 30 * 1e3) {
+      logger.info("Auth token expiring soon, refreshing...");
+      const newAuth = await refreshAuth();
+      currentApiKey = newAuth.key;
+      expiresAt = newAuth.expiresAt;
+    }
+    const headers = new Headers(init?.headers);
+    headers.set("Authorization", `Bearer ${currentApiKey}`);
+    return fetch(input, { ...init, headers });
+  };
+}
 function getStainlessClient(action, opts) {
   const headers = {
     "User-Agent": `Stainless/Action ${package_default.version}`
@@ -40836,11 +40857,12 @@ function wrapAction(actionType, fn) {
     let projectName;
     try {
       projectName = getInput("project", { required: true });
-      const apiKey = await getStainlessAuthToken();
+      const auth = await getStainlessAuth();
       stainless = getStainlessClient(actionType, {
         project: projectName,
-        apiKey,
-        logLevel: "warn"
+        apiKey: auth.key,
+        logLevel: "warn",
+        fetch: createAutoRefreshFetch(auth, getStainlessAuth)
       });
       await fn(stainless);
       await maybeReportResult({

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -37707,11 +37707,14 @@ function getGitHostToken() {
 function getRunUrl() {
   return isGitLabCI() ? `${process.env.CI_PROJECT_URL}/-/pipelines/${process.env.CI_PIPELINE_ID}` : `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 }
-async function getStainlessAuthToken() {
+async function getStainlessAuth() {
   const apiKey = getInput("stainless_api_key", { required: isGitLabCI() });
   if (apiKey) {
     logger.debug("Authenticating with provided Stainless API key");
-    return apiKey;
+    return {
+      key: apiKey,
+      expiresAt: null
+    };
   }
   logger.debug("Authenticating with GitHub OIDC");
   const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
@@ -37732,7 +37735,10 @@ async function getStainlessAuthToken() {
     if (!data.value) {
       throw new Error("No token in OIDC response");
     }
-    return data.value;
+    return {
+      key: data.value,
+      expiresAt: Date.now() + 300 * 1e3
+    };
   } catch (error) {
     throw new Error(
       `Failed to authenticate with GitHub OIDC. Make sure your workflow has 'id-token: write' permission and that you have the Stainless GitHub App installed: https://www.stainless.com/docs/guides/publish/#install-the-stainless-github-app. Error: ${error}`
@@ -40889,6 +40895,21 @@ var package_default = {
 };
 
 // src/stainless.ts
+function createAutoRefreshFetch(initialAuth, refreshAuth) {
+  let currentApiKey = initialAuth.key;
+  let expiresAt = initialAuth.expiresAt;
+  return async (input, init) => {
+    if (expiresAt != null && expiresAt - Date.now() < 30 * 1e3) {
+      logger.info("Auth token expiring soon, refreshing...");
+      const newAuth = await refreshAuth();
+      currentApiKey = newAuth.key;
+      expiresAt = newAuth.expiresAt;
+    }
+    const headers = new Headers(init?.headers);
+    headers.set("Authorization", `Bearer ${currentApiKey}`);
+    return fetch(input, { ...init, headers });
+  };
+}
 function getStainlessClient(action, opts) {
   const headers = {
     "User-Agent": `Stainless/Action ${package_default.version}`
@@ -40921,11 +40942,12 @@ function wrapAction(actionType, fn) {
     let projectName;
     try {
       projectName = getInput("project", { required: true });
-      const apiKey = await getStainlessAuthToken();
+      const auth = await getStainlessAuth();
       stainless = getStainlessClient(actionType, {
         project: projectName,
-        apiKey,
-        logLevel: "warn"
+        apiKey: auth.key,
+        logLevel: "warn",
+        fetch: createAutoRefreshFetch(auth, getStainlessAuth)
       });
       await fn(stainless);
       await maybeReportResult({

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -115,11 +115,17 @@ export function getRunUrl() {
     : `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 }
 
-export async function getStainlessAuthToken(): Promise<string> {
+export async function getStainlessAuth(): Promise<{
+  key: string;
+  expiresAt: number | null;
+}> {
   const apiKey = getInput("stainless_api_key", { required: isGitLabCI() });
   if (apiKey) {
     logger.debug("Authenticating with provided Stainless API key");
-    return apiKey;
+    return {
+      key: apiKey,
+      expiresAt: null,
+    };
   }
 
   logger.debug("Authenticating with GitHub OIDC");
@@ -144,7 +150,10 @@ export async function getStainlessAuthToken(): Promise<string> {
     if (!data.value) {
       throw new Error("No token in OIDC response");
     }
-    return data.value;
+    return {
+      key: data.value,
+      expiresAt: Date.now() + 300 * 1000,
+    };
   } catch (error) {
     throw new Error(
       `Failed to authenticate with GitHub OIDC. Make sure your workflow has 'id-token: write' permission ` +

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import Stainless from "@stainless-api/sdk";
 import { getStainlessClient } from "./stainless";
 import { readFileSync, writeFileSync } from "node:fs";
 import YAML from "yaml";
-import { getBooleanInput, getInput, getStainlessAuthToken } from "./compat";
+import { getBooleanInput, getInput, getStainlessAuth } from "./compat";
 import { logger } from "./logger";
 
 // https://www.conventionalcommits.org/en/v1.0.0/
@@ -16,7 +16,7 @@ export const isValidConventionalCommitMessage = (message: string) => {
 
 export async function main() {
   // inputs
-  const stainless_api_key = await getStainlessAuthToken();
+  const { key: stainless_api_key } = await getStainlessAuth();
   const inputPath = getInput("input_path", { required: true });
   const configPath = getInput("config_path", { required: false });
   let projectName = getInput("project_name", { required: false });

--- a/src/wrapAction.ts
+++ b/src/wrapAction.ts
@@ -1,7 +1,7 @@
 import Stainless from "@stainless-api/sdk";
 import { getInput } from "./compat/input";
-import { getStainlessAuthToken } from "./compat";
-import { getStainlessClient } from "./stainless";
+import { getStainlessAuth } from "./compat";
+import { createAutoRefreshFetch, getStainlessClient } from "./stainless";
 import { logger } from "./logger";
 
 const accumulatedBuildIds = new Set<string>();
@@ -27,11 +27,12 @@ export function wrapAction(
 
     try {
       projectName = getInput("project", { required: true });
-      const apiKey = await getStainlessAuthToken();
+      const auth = await getStainlessAuth();
       stainless = getStainlessClient(actionType, {
         project: projectName,
-        apiKey,
+        apiKey: auth.key,
         logLevel: "warn",
+        fetch: createAutoRefreshFetch(auth, getStainlessAuth),
       });
       await fn(stainless);
       await maybeReportResult({


### PR DESCRIPTION
OIDC tokens expire after five minutes. To allow the action to run and continue to make requests for longer than that amount of time, we use a custom `fetch` implementation that grabs a new token if needed.

Test plan: tried it out in my test repo