### PR TITLE
feat: make org, project optional if unambiguous

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -15,8 +15,10 @@ inputs:
       if not provided, requires 'id-token: write' permission). Required for GitLab CI.
     required: false
   project:
-    description: Stainless project name.
-    required: true
+    description: >-
+      Stainless project name. If omitted, will be auto-detected when the API key
+      has access to exactly one project.
+    required: false
   oas_path:
     description: >-
       Path to your OpenAPI spec. If omitted, and `merge_branch` is false,

--- a/dist/build.js
+++ b/dist/build.js
@@ -25,9 +25,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/yaml/dist/nodes/identity.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/identity.js
 var require_identity = __commonJS({
-  "node_modules/yaml/dist/nodes/identity.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/identity.js"(exports2) {
     "use strict";
     var ALIAS = Symbol.for("yaml.alias");
     var DOC = Symbol.for("yaml.document");
@@ -82,9 +82,9 @@ var require_identity = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/visit.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/visit.js
 var require_visit = __commonJS({
-  "node_modules/yaml/dist/visit.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/visit.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var BREAK = Symbol("break visit");
@@ -240,9 +240,9 @@ var require_visit = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/directives.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/directives.js
 var require_directives = __commonJS({
-  "node_modules/yaml/dist/doc/directives.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/directives.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -411,9 +411,9 @@ var require_directives = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/anchors.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/anchors.js
 var require_anchors = __commonJS({
-  "node_modules/yaml/dist/doc/anchors.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/anchors.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -481,9 +481,9 @@ var require_anchors = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/applyReviver.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/applyReviver.js
 var require_applyReviver = __commonJS({
-  "node_modules/yaml/dist/doc/applyReviver.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/applyReviver.js"(exports2) {
     "use strict";
     function applyReviver(reviver, obj, key, val) {
       if (val && typeof val === "object") {
@@ -531,9 +531,9 @@ var require_applyReviver = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/toJS.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/toJS.js
 var require_toJS = __commonJS({
-  "node_modules/yaml/dist/nodes/toJS.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/toJS.js"(exports2) {
     "use strict";
     var identity = require_identity();
     function toJS(value, arg, ctx) {
@@ -561,9 +561,9 @@ var require_toJS = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Node.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Node.js
 var require_Node = __commonJS({
-  "node_modules/yaml/dist/nodes/Node.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Node.js"(exports2) {
     "use strict";
     var applyReviver = require_applyReviver();
     var identity = require_identity();
@@ -602,9 +602,9 @@ var require_Node = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Alias.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Alias.js
 var require_Alias = __commonJS({
-  "node_modules/yaml/dist/nodes/Alias.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Alias.js"(exports2) {
     "use strict";
     var anchors = require_anchors();
     var visit = require_visit();
@@ -663,7 +663,7 @@ var require_Alias = __commonJS({
           toJS.toJS(source, null, ctx);
           data = anchors2.get(source);
         }
-        if (!data || data.res === void 0) {
+        if (data?.res === void 0) {
           const msg = "This should not happen: Alias anchor was not resolved?";
           throw new ReferenceError(msg);
         }
@@ -716,9 +716,9 @@ var require_Alias = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Scalar.js
 var require_Scalar = __commonJS({
-  "node_modules/yaml/dist/nodes/Scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Scalar.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Node = require_Node();
@@ -746,9 +746,9 @@ var require_Scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/createNode.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/createNode.js
 var require_createNode = __commonJS({
-  "node_modules/yaml/dist/doc/createNode.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/createNode.js"(exports2) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -821,9 +821,9 @@ var require_createNode = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Collection.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Collection.js
 var require_Collection = __commonJS({
-  "node_modules/yaml/dist/nodes/Collection.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Collection.js"(exports2) {
     "use strict";
     var createNode = require_createNode();
     var identity = require_identity();
@@ -964,9 +964,9 @@ var require_Collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyComment.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyComment.js
 var require_stringifyComment = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyComment.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyComment.js"(exports2) {
     "use strict";
     var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
     function indentComment(comment, indent) {
@@ -981,9 +981,9 @@ var require_stringifyComment = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/foldFlowLines.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/foldFlowLines.js
 var require_foldFlowLines = __commonJS({
-  "node_modules/yaml/dist/stringify/foldFlowLines.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/foldFlowLines.js"(exports2) {
     "use strict";
     var FOLD_FLOW = "flow";
     var FOLD_BLOCK = "block";
@@ -1117,9 +1117,9 @@ ${indent}${text.slice(fold + 1, end2)}`;
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyString.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyString.js
 var require_stringifyString = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyString.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyString.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var foldFlowLines = require_foldFlowLines();
@@ -1400,9 +1400,9 @@ ${indent}`);
   }
 });
 
-// node_modules/yaml/dist/stringify/stringify.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringify.js
 var require_stringify = __commonJS({
-  "node_modules/yaml/dist/stringify/stringify.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringify.js"(exports2) {
     "use strict";
     var anchors = require_anchors();
     var identity = require_identity();
@@ -1523,9 +1523,9 @@ ${ctx.indent}${str}`;
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyPair.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyPair.js
 var require_stringifyPair = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyPair.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyPair.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -1613,7 +1613,7 @@ ${indent}:`;
 ${stringifyComment.indentComment(cs, ctx.indent)}`;
         }
         if (valueStr === "" && !ctx.inFlow) {
-          if (ws === "\n")
+          if (ws === "\n" && valueComment)
             ws = "\n\n";
         } else {
           ws += `
@@ -1656,9 +1656,9 @@ ${ctx.indent}`;
   }
 });
 
-// node_modules/yaml/dist/log.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/log.js
 var require_log = __commonJS({
-  "node_modules/yaml/dist/log.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/log.js"(exports2) {
     "use strict";
     var node_process = require("process");
     function debug(logLevel, ...messages) {
@@ -1678,9 +1678,9 @@ var require_log = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/merge.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/merge.js
 var require_merge = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -1735,9 +1735,9 @@ var require_merge = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/addPairToJSMap.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/addPairToJSMap.js
 var require_addPairToJSMap = __commonJS({
-  "node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports2) {
     "use strict";
     var log = require_log();
     var merge = require_merge();
@@ -1799,9 +1799,9 @@ var require_addPairToJSMap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Pair.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Pair.js
 var require_Pair = __commonJS({
-  "node_modules/yaml/dist/nodes/Pair.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Pair.js"(exports2) {
     "use strict";
     var createNode = require_createNode();
     var stringifyPair = require_stringifyPair();
@@ -1839,9 +1839,9 @@ var require_Pair = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyCollection.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyCollection.js
 var require_stringifyCollection = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyCollection.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyCollection.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var stringify3 = require_stringify();
@@ -1983,9 +1983,9 @@ ${indent}${end}`;
   }
 });
 
-// node_modules/yaml/dist/nodes/YAMLMap.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLMap.js
 var require_YAMLMap = __commonJS({
-  "node_modules/yaml/dist/nodes/YAMLMap.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLMap.js"(exports2) {
     "use strict";
     var stringifyCollection = require_stringifyCollection();
     var addPairToJSMap = require_addPairToJSMap();
@@ -2127,9 +2127,9 @@ var require_YAMLMap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/map.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/map.js
 var require_map = __commonJS({
-  "node_modules/yaml/dist/schema/common/map.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/map.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var YAMLMap = require_YAMLMap();
@@ -2149,9 +2149,9 @@ var require_map = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/YAMLSeq.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLSeq.js
 var require_YAMLSeq = __commonJS({
-  "node_modules/yaml/dist/nodes/YAMLSeq.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLSeq.js"(exports2) {
     "use strict";
     var createNode = require_createNode();
     var stringifyCollection = require_stringifyCollection();
@@ -2265,9 +2265,9 @@ var require_YAMLSeq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/seq.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/seq.js
 var require_seq = __commonJS({
-  "node_modules/yaml/dist/schema/common/seq.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/seq.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var YAMLSeq = require_YAMLSeq();
@@ -2287,9 +2287,9 @@ var require_seq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/string.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/string.js
 var require_string = __commonJS({
-  "node_modules/yaml/dist/schema/common/string.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/string.js"(exports2) {
     "use strict";
     var stringifyString = require_stringifyString();
     var string = {
@@ -2306,9 +2306,9 @@ var require_string = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/null.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/null.js
 var require_null = __commonJS({
-  "node_modules/yaml/dist/schema/common/null.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/null.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var nullTag = {
@@ -2324,9 +2324,9 @@ var require_null = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/bool.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/bool.js
 var require_bool = __commonJS({
-  "node_modules/yaml/dist/schema/core/bool.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/bool.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var boolTag = {
@@ -2348,9 +2348,9 @@ var require_bool = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyNumber.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyNumber.js
 var require_stringifyNumber = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyNumber.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyNumber.js"(exports2) {
     "use strict";
     function stringifyNumber({ format, minFractionDigits, tag, value }) {
       if (typeof value === "bigint")
@@ -2358,7 +2358,7 @@ var require_stringifyNumber = __commonJS({
       const num = typeof value === "number" ? value : Number(value);
       if (!isFinite(num))
         return isNaN(num) ? ".nan" : num < 0 ? "-.inf" : ".inf";
-      let n = JSON.stringify(value);
+      let n = Object.is(value, -0) ? "-0" : JSON.stringify(value);
       if (!format && minFractionDigits && (!tag || tag === "tag:yaml.org,2002:float") && /^\d/.test(n)) {
         let i = n.indexOf(".");
         if (i < 0) {
@@ -2375,9 +2375,9 @@ var require_stringifyNumber = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/float.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/float.js
 var require_float = __commonJS({
-  "node_modules/yaml/dist/schema/core/float.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/float.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -2421,9 +2421,9 @@ var require_float = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/int.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/int.js
 var require_int = __commonJS({
-  "node_modules/yaml/dist/schema/core/int.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/int.js"(exports2) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -2466,9 +2466,9 @@ var require_int = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/schema.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/schema.js
 var require_schema = __commonJS({
-  "node_modules/yaml/dist/schema/core/schema.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/schema.js"(exports2) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -2494,9 +2494,9 @@ var require_schema = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/json/schema.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/json/schema.js
 var require_schema2 = __commonJS({
-  "node_modules/yaml/dist/schema/json/schema.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/json/schema.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var map = require_map();
@@ -2561,9 +2561,9 @@ var require_schema2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/binary.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/binary.js
 var require_binary = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports2) {
     "use strict";
     var node_buffer = require("buffer");
     var Scalar = require_Scalar();
@@ -2627,9 +2627,9 @@ var require_binary = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/pairs.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/pairs.js
 var require_pairs = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -2705,9 +2705,9 @@ ${cn.comment}` : item.comment;
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/omap.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/omap.js
 var require_omap = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var toJS = require_toJS();
@@ -2783,9 +2783,9 @@ var require_omap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/bool.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/bool.js
 var require_bool2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     function boolStringify({ value, source }, ctx) {
@@ -2815,9 +2815,9 @@ var require_bool2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/float.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/float.js
 var require_float2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -2864,9 +2864,9 @@ var require_float2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/int.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/int.js
 var require_int2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports2) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -2943,9 +2943,9 @@ var require_int2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/set.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/set.js
 var require_set = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -3032,9 +3032,9 @@ var require_set = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
 var require_timestamp = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports2) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     function parseSexagesimal(str, asBigInt) {
@@ -3120,9 +3120,9 @@ var require_timestamp = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/schema.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/schema.js
 var require_schema3 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports2) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -3164,9 +3164,9 @@ var require_schema3 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/tags.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/tags.js
 var require_tags = __commonJS({
-  "node_modules/yaml/dist/schema/tags.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/tags.js"(exports2) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -3258,9 +3258,9 @@ var require_tags = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/Schema.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/Schema.js
 var require_Schema = __commonJS({
-  "node_modules/yaml/dist/schema/Schema.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/Schema.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var map = require_map();
@@ -3290,9 +3290,9 @@ var require_Schema = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyDocument.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyDocument.js
 var require_stringifyDocument = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyDocument.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyDocument.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var stringify3 = require_stringify();
@@ -3370,9 +3370,9 @@ var require_stringifyDocument = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/Document.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/Document.js
 var require_Document = __commonJS({
-  "node_modules/yaml/dist/doc/Document.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/Document.js"(exports2) {
     "use strict";
     var Alias = require_Alias();
     var Collection = require_Collection();
@@ -3679,9 +3679,9 @@ var require_Document = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/errors.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/errors.js
 var require_errors = __commonJS({
-  "node_modules/yaml/dist/errors.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/errors.js"(exports2) {
     "use strict";
     var YAMLError = class extends Error {
       constructor(name, pos, code, message) {
@@ -3726,7 +3726,7 @@ var require_errors = __commonJS({
       if (/[^ ]/.test(lineStr)) {
         let count = 1;
         const end = error.linePos[1];
-        if (end && end.line === line && end.col > col) {
+        if (end?.line === line && end.col > col) {
           count = Math.max(1, Math.min(end.col - col, 80 - ci));
         }
         const pointer = " ".repeat(ci) + "^".repeat(count);
@@ -3744,9 +3744,9 @@ ${pointer}
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-props.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-props.js
 var require_resolve_props = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-props.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-props.js"(exports2) {
     "use strict";
     function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
       let spaceBefore = false;
@@ -3878,9 +3878,9 @@ var require_resolve_props = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-contains-newline.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-contains-newline.js
 var require_util_contains_newline = __commonJS({
-  "node_modules/yaml/dist/compose/util-contains-newline.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-contains-newline.js"(exports2) {
     "use strict";
     function containsNewline(key) {
       if (!key)
@@ -3920,9 +3920,9 @@ var require_util_contains_newline = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-flow-indent-check.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-flow-indent-check.js
 var require_util_flow_indent_check = __commonJS({
-  "node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports2) {
     "use strict";
     var utilContainsNewline = require_util_contains_newline();
     function flowIndentCheck(indent, fc, onError) {
@@ -3938,9 +3938,9 @@ var require_util_flow_indent_check = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-map-includes.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-map-includes.js
 var require_util_map_includes = __commonJS({
-  "node_modules/yaml/dist/compose/util-map-includes.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-map-includes.js"(exports2) {
     "use strict";
     var identity = require_identity();
     function mapIncludes(ctx, items, search) {
@@ -3954,9 +3954,9 @@ var require_util_map_includes = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-map.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-map.js
 var require_resolve_block_map = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-map.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-map.js"(exports2) {
     "use strict";
     var Pair = require_Pair();
     var YAMLMap = require_YAMLMap();
@@ -4062,9 +4062,9 @@ var require_resolve_block_map = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-seq.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-seq.js
 var require_resolve_block_seq = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-seq.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-seq.js"(exports2) {
     "use strict";
     var YAMLSeq = require_YAMLSeq();
     var resolveProps = require_resolve_props();
@@ -4089,7 +4089,7 @@ var require_resolve_block_seq = __commonJS({
         });
         if (!props.found) {
           if (props.anchor || props.tag || value) {
-            if (value && value.type === "block-seq")
+            if (value?.type === "block-seq")
               onError(props.end, "BAD_INDENT", "All sequence items must start at the same column");
             else
               onError(offset, "MISSING_CHAR", "Sequence item without - indicator");
@@ -4113,9 +4113,9 @@ var require_resolve_block_seq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-end.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-end.js
 var require_resolve_end = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-end.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-end.js"(exports2) {
     "use strict";
     function resolveEnd(end, offset, reqSpace, onError) {
       let comment = "";
@@ -4156,9 +4156,9 @@ var require_resolve_end = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-flow-collection.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-collection.js
 var require_resolve_flow_collection = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -4286,7 +4286,7 @@ var require_resolve_flow_collection = __commonJS({
                 onError(valueProps.found, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit flow sequence key");
             }
           } else if (value) {
-            if ("source" in value && value.source && value.source[0] === ":")
+            if ("source" in value && value.source?.[0] === ":")
               onError(value, "MISSING_CHAR", `Missing space after : in ${fcName}`);
             else
               onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
@@ -4323,7 +4323,7 @@ var require_resolve_flow_collection = __commonJS({
       const expectedEnd = isMap ? "}" : "]";
       const [ce, ...ee] = fc.end;
       let cePos = offset;
-      if (ce && ce.source === expectedEnd)
+      if (ce?.source === expectedEnd)
         cePos = ce.offset + ce.source.length;
       else {
         const name = fcName[0].toUpperCase() + fcName.substring(1);
@@ -4350,9 +4350,9 @@ var require_resolve_flow_collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-collection.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-collection.js
 var require_compose_collection = __commonJS({
-  "node_modules/yaml/dist/compose/compose-collection.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-collection.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -4390,7 +4390,7 @@ var require_compose_collection = __commonJS({
       let tag = ctx.schema.tags.find((t) => t.tag === tagName && t.collection === expType);
       if (!tag) {
         const kt = ctx.schema.knownTags[tagName];
-        if (kt && kt.collection === expType) {
+        if (kt?.collection === expType) {
           ctx.schema.tags.push(Object.assign({}, kt, { default: false }));
           tag = kt;
         } else {
@@ -4415,9 +4415,9 @@ var require_compose_collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-scalar.js
 var require_resolve_block_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     function resolveBlockScalar(ctx, scalar, onError) {
@@ -4598,9 +4598,9 @@ var require_resolve_block_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-flow-scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-scalar.js
 var require_resolve_flow_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var resolveEnd = require_resolve_end();
@@ -4817,9 +4817,9 @@ var require_resolve_flow_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-scalar.js
 var require_compose_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/compose-scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-scalar.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -4898,9 +4898,9 @@ var require_compose_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-empty-scalar-position.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-empty-scalar-position.js
 var require_util_empty_scalar_position = __commonJS({
-  "node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports2) {
     "use strict";
     function emptyScalarPosition(offset, before, pos) {
       if (before) {
@@ -4928,9 +4928,9 @@ var require_util_empty_scalar_position = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-node.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-node.js
 var require_compose_node = __commonJS({
-  "node_modules/yaml/dist/compose/compose-node.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-node.js"(exports2) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -5029,9 +5029,9 @@ var require_compose_node = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-doc.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-doc.js
 var require_compose_doc = __commonJS({
-  "node_modules/yaml/dist/compose/compose-doc.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-doc.js"(exports2) {
     "use strict";
     var Document = require_Document();
     var composeNode = require_compose_node();
@@ -5072,9 +5072,9 @@ var require_compose_doc = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/composer.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/composer.js
 var require_composer = __commonJS({
-  "node_modules/yaml/dist/compose/composer.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/composer.js"(exports2) {
     "use strict";
     var node_process = require("process");
     var directives = require_directives();
@@ -5278,9 +5278,9 @@ ${end.comment}` : end.comment;
   }
 });
 
-// node_modules/yaml/dist/parse/cst-scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-scalar.js
 var require_cst_scalar = __commonJS({
-  "node_modules/yaml/dist/parse/cst-scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-scalar.js"(exports2) {
     "use strict";
     var resolveBlockScalar = require_resolve_block_scalar();
     var resolveFlowScalar = require_resolve_flow_scalar();
@@ -5463,9 +5463,9 @@ var require_cst_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst-stringify.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-stringify.js
 var require_cst_stringify = __commonJS({
-  "node_modules/yaml/dist/parse/cst-stringify.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-stringify.js"(exports2) {
     "use strict";
     var stringify3 = (cst) => "type" in cst ? stringifyToken(cst) : stringifyItem(cst);
     function stringifyToken(token) {
@@ -5524,9 +5524,9 @@ var require_cst_stringify = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst-visit.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-visit.js
 var require_cst_visit = __commonJS({
-  "node_modules/yaml/dist/parse/cst-visit.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-visit.js"(exports2) {
     "use strict";
     var BREAK = Symbol("break visit");
     var SKIP = Symbol("skip children");
@@ -5586,9 +5586,9 @@ var require_cst_visit = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst.js
 var require_cst = __commonJS({
-  "node_modules/yaml/dist/parse/cst.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst.js"(exports2) {
     "use strict";
     var cstScalar = require_cst_scalar();
     var cstStringify = require_cst_stringify();
@@ -5688,9 +5688,9 @@ var require_cst = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/lexer.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/lexer.js
 var require_lexer = __commonJS({
-  "node_modules/yaml/dist/parse/lexer.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/lexer.js"(exports2) {
     "use strict";
     var cst = require_cst();
     function isEmpty(ch) {
@@ -6267,9 +6267,9 @@ var require_lexer = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/line-counter.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/line-counter.js
 var require_line_counter = __commonJS({
-  "node_modules/yaml/dist/parse/line-counter.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/line-counter.js"(exports2) {
     "use strict";
     var LineCounter = class {
       constructor() {
@@ -6298,9 +6298,9 @@ var require_line_counter = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/parser.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/parser.js
 var require_parser = __commonJS({
-  "node_modules/yaml/dist/parse/parser.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/parser.js"(exports2) {
     "use strict";
     var node_process = require("process");
     var cst = require_cst();
@@ -6488,7 +6488,7 @@ var require_parser = __commonJS({
       }
       *step() {
         const top = this.peek(1);
-        if (this.type === "doc-end" && (!top || top.type !== "doc-end")) {
+        if (this.type === "doc-end" && top?.type !== "doc-end") {
           while (this.stack.length > 0)
             yield* this.pop();
           this.stack.push({
@@ -6966,7 +6966,7 @@ var require_parser = __commonJS({
           do {
             yield* this.pop();
             top = this.peek(1);
-          } while (top && top.type === "flow-collection");
+          } while (top?.type === "flow-collection");
         } else if (fc.end.length === 0) {
           switch (this.type) {
             case "comma":
@@ -7165,9 +7165,9 @@ var require_parser = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/public-api.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/public-api.js
 var require_public_api = __commonJS({
-  "node_modules/yaml/dist/public-api.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/public-api.js"(exports2) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -7262,9 +7262,9 @@ var require_public_api = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/index.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/index.js
 var require_dist = __commonJS({
-  "node_modules/yaml/dist/index.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/index.js"(exports2) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -7314,9 +7314,9 @@ var require_dist = __commonJS({
   }
 });
 
-// node_modules/libsodium/dist/modules/libsodium.js
+// node_modules/.pnpm/libsodium@0.7.15/node_modules/libsodium/dist/modules/libsodium.js
 var require_libsodium = __commonJS({
-  "node_modules/libsodium/dist/modules/libsodium.js"(exports2, module2) {
+  "node_modules/.pnpm/libsodium@0.7.15/node_modules/libsodium/dist/modules/libsodium.js"(exports2, module2) {
     !(function(A) {
       function I(A2) {
         "use strict";
@@ -9920,9 +9920,9 @@ var require_libsodium = __commonJS({
   }
 });
 
-// node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js
+// node_modules/.pnpm/libsodium-wrappers@0.7.15/node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js
 var require_libsodium_wrappers = __commonJS({
-  "node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js"(exports2) {
+  "node_modules/.pnpm/libsodium-wrappers@0.7.15/node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js"(exports2) {
     !(function(e) {
       function a(e2, a2) {
         "use strict";
@@ -12523,9 +12523,9 @@ var require_libsodium_wrappers = __commonJS({
   }
 });
 
-// node_modules/safe-buffer/index.js
+// node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer/index.js
 var require_safe_buffer = __commonJS({
-  "node_modules/safe-buffer/index.js"(exports2, module2) {
+  "node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer/index.js"(exports2, module2) {
     var buffer = require("buffer");
     var Buffer2 = buffer.Buffer;
     function copyProps(src, dst) {
@@ -12581,9 +12581,9 @@ var require_safe_buffer = __commonJS({
   }
 });
 
-// node_modules/jws/lib/data-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/data-stream.js
 var require_data_stream = __commonJS({
-  "node_modules/jws/lib/data-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/data-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var Stream = require("stream");
     var util = require("util");
@@ -12629,9 +12629,9 @@ var require_data_stream = __commonJS({
   }
 });
 
-// node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js
+// node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js
 var require_param_bytes_for_alg = __commonJS({
-  "node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js"(exports2, module2) {
+  "node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js"(exports2, module2) {
     "use strict";
     function getParamSize(keySize) {
       var result = (keySize / 8 | 0) + (keySize % 8 === 0 ? 0 : 1);
@@ -12653,9 +12653,9 @@ var require_param_bytes_for_alg = __commonJS({
   }
 });
 
-// node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js
+// node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js
 var require_ecdsa_sig_formatter = __commonJS({
-  "node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js"(exports2, module2) {
+  "node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js"(exports2, module2) {
     "use strict";
     var Buffer2 = require_safe_buffer().Buffer;
     var getParamBytesForAlg = require_param_bytes_for_alg();
@@ -12793,9 +12793,9 @@ var require_ecdsa_sig_formatter = __commonJS({
   }
 });
 
-// node_modules/buffer-equal-constant-time/index.js
+// node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time/index.js
 var require_buffer_equal_constant_time = __commonJS({
-  "node_modules/buffer-equal-constant-time/index.js"(exports2, module2) {
+  "node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time/index.js"(exports2, module2) {
     "use strict";
     var Buffer2 = require("buffer").Buffer;
     var SlowBuffer = require("buffer").SlowBuffer;
@@ -12827,9 +12827,9 @@ var require_buffer_equal_constant_time = __commonJS({
   }
 });
 
-// node_modules/jwa/index.js
+// node_modules/.pnpm/jwa@2.0.1/node_modules/jwa/index.js
 var require_jwa = __commonJS({
-  "node_modules/jwa/index.js"(exports2, module2) {
+  "node_modules/.pnpm/jwa@2.0.1/node_modules/jwa/index.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var crypto2 = require("crypto");
     var formatEcdsa = require_ecdsa_sig_formatter();
@@ -13038,7 +13038,7 @@ var require_jwa = __commonJS({
         es: createECDSAVerifer,
         none: createNoneVerifier
       };
-      var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/i);
+      var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/);
       if (!match)
         throw typeError(MSG_INVALID_ALGORITHM, algorithm);
       var algo = (match[1] || match[3]).toLowerCase();
@@ -13051,9 +13051,9 @@ var require_jwa = __commonJS({
   }
 });
 
-// node_modules/jws/lib/tostring.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/tostring.js
 var require_tostring = __commonJS({
-  "node_modules/jws/lib/tostring.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/tostring.js"(exports2, module2) {
     var Buffer2 = require("buffer").Buffer;
     module2.exports = function toString(obj) {
       if (typeof obj === "string")
@@ -13065,9 +13065,9 @@ var require_tostring = __commonJS({
   }
 });
 
-// node_modules/jws/lib/sign-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/sign-stream.js
 var require_sign_stream = __commonJS({
-  "node_modules/jws/lib/sign-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/sign-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var DataStream = require_data_stream();
     var jwa = require_jwa();
@@ -13094,7 +13094,12 @@ var require_sign_stream = __commonJS({
       return util.format("%s.%s", securedInput, signature);
     }
     function SignStream(opts) {
-      var secret = opts.secret || opts.privateKey || opts.key;
+      var secret = opts.secret;
+      secret = secret == null ? opts.privateKey : secret;
+      secret = secret == null ? opts.key : secret;
+      if (/^hs/i.test(opts.header.alg) === true && secret == null) {
+        throw new TypeError("secret must be a string or buffer or a KeyObject");
+      }
       var secretStream = new DataStream(secret);
       this.readable = true;
       this.header = opts.header;
@@ -13135,9 +13140,9 @@ var require_sign_stream = __commonJS({
   }
 });
 
-// node_modules/jws/lib/verify-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/verify-stream.js
 var require_verify_stream = __commonJS({
-  "node_modules/jws/lib/verify-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/verify-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var DataStream = require_data_stream();
     var jwa = require_jwa();
@@ -13206,7 +13211,12 @@ var require_verify_stream = __commonJS({
     }
     function VerifyStream(opts) {
       opts = opts || {};
-      var secretOrKey = opts.secret || opts.publicKey || opts.key;
+      var secretOrKey = opts.secret;
+      secretOrKey = secretOrKey == null ? opts.publicKey : secretOrKey;
+      secretOrKey = secretOrKey == null ? opts.key : secretOrKey;
+      if (/^hs/i.test(opts.algorithm) === true && secretOrKey == null) {
+        throw new TypeError("secret must be a string or buffer or a KeyObject");
+      }
       var secretStream = new DataStream(secretOrKey);
       this.readable = true;
       this.algorithm = opts.algorithm;
@@ -13245,9 +13255,9 @@ var require_verify_stream = __commonJS({
   }
 });
 
-// node_modules/jws/index.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/index.js
 var require_jws = __commonJS({
-  "node_modules/jws/index.js"(exports2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/index.js"(exports2) {
     var SignStream = require_sign_stream();
     var VerifyStream = require_verify_stream();
     var ALGORITHMS = [
@@ -13278,9 +13288,9 @@ var require_jws = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/decode.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/decode.js
 var require_decode = __commonJS({
-  "node_modules/jsonwebtoken/decode.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/decode.js"(exports2, module2) {
     var jws = require_jws();
     module2.exports = function(jwt, options) {
       options = options || {};
@@ -13310,9 +13320,9 @@ var require_decode = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/JsonWebTokenError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/JsonWebTokenError.js
 var require_JsonWebTokenError = __commonJS({
-  "node_modules/jsonwebtoken/lib/JsonWebTokenError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/JsonWebTokenError.js"(exports2, module2) {
     var JsonWebTokenError = function(message, error) {
       Error.call(this, message);
       if (Error.captureStackTrace) {
@@ -13328,9 +13338,9 @@ var require_JsonWebTokenError = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/NotBeforeError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/NotBeforeError.js
 var require_NotBeforeError = __commonJS({
-  "node_modules/jsonwebtoken/lib/NotBeforeError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/NotBeforeError.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var NotBeforeError = function(message, date) {
       JsonWebTokenError.call(this, message);
@@ -13343,9 +13353,9 @@ var require_NotBeforeError = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/TokenExpiredError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/TokenExpiredError.js
 var require_TokenExpiredError = __commonJS({
-  "node_modules/jsonwebtoken/lib/TokenExpiredError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/TokenExpiredError.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var TokenExpiredError = function(message, expiredAt) {
       JsonWebTokenError.call(this, message);
@@ -13358,9 +13368,9 @@ var require_TokenExpiredError = __commonJS({
   }
 });
 
-// node_modules/ms/index.js
+// node_modules/.pnpm/ms@2.1.3/node_modules/ms/index.js
 var require_ms = __commonJS({
-  "node_modules/ms/index.js"(exports2, module2) {
+  "node_modules/.pnpm/ms@2.1.3/node_modules/ms/index.js"(exports2, module2) {
     var s = 1e3;
     var m = s * 60;
     var h = m * 60;
@@ -13474,9 +13484,9 @@ var require_ms = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/timespan.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/timespan.js
 var require_timespan = __commonJS({
-  "node_modules/jsonwebtoken/lib/timespan.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/timespan.js"(exports2, module2) {
     var ms = require_ms();
     module2.exports = function(time, iat) {
       var timestamp = iat || Math.floor(Date.now() / 1e3);
@@ -13495,9 +13505,9 @@ var require_timespan = __commonJS({
   }
 });
 
-// node_modules/semver/internal/constants.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/constants.js
 var require_constants = __commonJS({
-  "node_modules/semver/internal/constants.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/constants.js"(exports2, module2) {
     "use strict";
     var SEMVER_SPEC_VERSION = "2.0.0";
     var MAX_LENGTH = 256;
@@ -13527,9 +13537,9 @@ var require_constants = __commonJS({
   }
 });
 
-// node_modules/semver/internal/debug.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/debug.js
 var require_debug = __commonJS({
-  "node_modules/semver/internal/debug.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/debug.js"(exports2, module2) {
     "use strict";
     var debug = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
     };
@@ -13537,9 +13547,9 @@ var require_debug = __commonJS({
   }
 });
 
-// node_modules/semver/internal/re.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/re.js
 var require_re = __commonJS({
-  "node_modules/semver/internal/re.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/re.js"(exports2, module2) {
     "use strict";
     var {
       MAX_SAFE_COMPONENT_LENGTH,
@@ -13625,9 +13635,9 @@ var require_re = __commonJS({
   }
 });
 
-// node_modules/semver/internal/parse-options.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/parse-options.js
 var require_parse_options = __commonJS({
-  "node_modules/semver/internal/parse-options.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/parse-options.js"(exports2, module2) {
     "use strict";
     var looseOption = Object.freeze({ loose: true });
     var emptyOpts = Object.freeze({});
@@ -13644,12 +13654,15 @@ var require_parse_options = __commonJS({
   }
 });
 
-// node_modules/semver/internal/identifiers.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/identifiers.js
 var require_identifiers = __commonJS({
-  "node_modules/semver/internal/identifiers.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/identifiers.js"(exports2, module2) {
     "use strict";
     var numeric = /^[0-9]+$/;
     var compareIdentifiers = (a, b) => {
+      if (typeof a === "number" && typeof b === "number") {
+        return a === b ? 0 : a < b ? -1 : 1;
+      }
       const anum = numeric.test(a);
       const bnum = numeric.test(b);
       if (anum && bnum) {
@@ -13666,9 +13679,9 @@ var require_identifiers = __commonJS({
   }
 });
 
-// node_modules/semver/classes/semver.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js
 var require_semver = __commonJS({
-  "node_modules/semver/classes/semver.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js"(exports2, module2) {
     "use strict";
     var debug = require_debug();
     var { MAX_LENGTH, MAX_SAFE_INTEGER } = require_constants();
@@ -13756,7 +13769,25 @@ var require_semver = __commonJS({
         if (!(other instanceof _SemVer)) {
           other = new _SemVer(other, this.options);
         }
-        return compareIdentifiers(this.major, other.major) || compareIdentifiers(this.minor, other.minor) || compareIdentifiers(this.patch, other.patch);
+        if (this.major < other.major) {
+          return -1;
+        }
+        if (this.major > other.major) {
+          return 1;
+        }
+        if (this.minor < other.minor) {
+          return -1;
+        }
+        if (this.minor > other.minor) {
+          return 1;
+        }
+        if (this.patch < other.patch) {
+          return -1;
+        }
+        if (this.patch > other.patch) {
+          return 1;
+        }
+        return 0;
       }
       comparePre(other) {
         if (!(other instanceof _SemVer)) {
@@ -13927,9 +13958,9 @@ var require_semver = __commonJS({
   }
 });
 
-// node_modules/semver/functions/parse.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/parse.js
 var require_parse = __commonJS({
-  "node_modules/semver/functions/parse.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/parse.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var parse = (version, options, throwErrors = false) => {
@@ -13949,9 +13980,9 @@ var require_parse = __commonJS({
   }
 });
 
-// node_modules/semver/functions/valid.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/valid.js
 var require_valid = __commonJS({
-  "node_modules/semver/functions/valid.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/valid.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var valid = (version, options) => {
@@ -13962,9 +13993,9 @@ var require_valid = __commonJS({
   }
 });
 
-// node_modules/semver/functions/clean.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/clean.js
 var require_clean = __commonJS({
-  "node_modules/semver/functions/clean.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/clean.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var clean = (version, options) => {
@@ -13975,9 +14006,9 @@ var require_clean = __commonJS({
   }
 });
 
-// node_modules/semver/functions/inc.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/inc.js
 var require_inc = __commonJS({
-  "node_modules/semver/functions/inc.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/inc.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var inc = (version, release, options, identifier, identifierBase) => {
@@ -13999,9 +14030,9 @@ var require_inc = __commonJS({
   }
 });
 
-// node_modules/semver/functions/diff.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/diff.js
 var require_diff = __commonJS({
-  "node_modules/semver/functions/diff.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/diff.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var diff = (version1, version2) => {
@@ -14043,9 +14074,9 @@ var require_diff = __commonJS({
   }
 });
 
-// node_modules/semver/functions/major.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/major.js
 var require_major = __commonJS({
-  "node_modules/semver/functions/major.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/major.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var major = (a, loose) => new SemVer(a, loose).major;
@@ -14053,9 +14084,9 @@ var require_major = __commonJS({
   }
 });
 
-// node_modules/semver/functions/minor.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/minor.js
 var require_minor = __commonJS({
-  "node_modules/semver/functions/minor.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/minor.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var minor = (a, loose) => new SemVer(a, loose).minor;
@@ -14063,9 +14094,9 @@ var require_minor = __commonJS({
   }
 });
 
-// node_modules/semver/functions/patch.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/patch.js
 var require_patch = __commonJS({
-  "node_modules/semver/functions/patch.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/patch.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var patch = (a, loose) => new SemVer(a, loose).patch;
@@ -14073,9 +14104,9 @@ var require_patch = __commonJS({
   }
 });
 
-// node_modules/semver/functions/prerelease.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/prerelease.js
 var require_prerelease = __commonJS({
-  "node_modules/semver/functions/prerelease.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/prerelease.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var prerelease = (version, options) => {
@@ -14086,9 +14117,9 @@ var require_prerelease = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js
 var require_compare = __commonJS({
-  "node_modules/semver/functions/compare.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var compare = (a, b, loose) => new SemVer(a, loose).compare(new SemVer(b, loose));
@@ -14096,9 +14127,9 @@ var require_compare = __commonJS({
   }
 });
 
-// node_modules/semver/functions/rcompare.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rcompare.js
 var require_rcompare = __commonJS({
-  "node_modules/semver/functions/rcompare.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rcompare.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var rcompare = (a, b, loose) => compare(b, a, loose);
@@ -14106,9 +14137,9 @@ var require_rcompare = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare-loose.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-loose.js
 var require_compare_loose = __commonJS({
-  "node_modules/semver/functions/compare-loose.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-loose.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var compareLoose = (a, b) => compare(a, b, true);
@@ -14116,9 +14147,9 @@ var require_compare_loose = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare-build.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-build.js
 var require_compare_build = __commonJS({
-  "node_modules/semver/functions/compare-build.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-build.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var compareBuild = (a, b, loose) => {
@@ -14130,9 +14161,9 @@ var require_compare_build = __commonJS({
   }
 });
 
-// node_modules/semver/functions/sort.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/sort.js
 var require_sort = __commonJS({
-  "node_modules/semver/functions/sort.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/sort.js"(exports2, module2) {
     "use strict";
     var compareBuild = require_compare_build();
     var sort = (list, loose) => list.sort((a, b) => compareBuild(a, b, loose));
@@ -14140,9 +14171,9 @@ var require_sort = __commonJS({
   }
 });
 
-// node_modules/semver/functions/rsort.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rsort.js
 var require_rsort = __commonJS({
-  "node_modules/semver/functions/rsort.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rsort.js"(exports2, module2) {
     "use strict";
     var compareBuild = require_compare_build();
     var rsort = (list, loose) => list.sort((a, b) => compareBuild(b, a, loose));
@@ -14150,9 +14181,9 @@ var require_rsort = __commonJS({
   }
 });
 
-// node_modules/semver/functions/gt.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gt.js
 var require_gt = __commonJS({
-  "node_modules/semver/functions/gt.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gt.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var gt = (a, b, loose) => compare(a, b, loose) > 0;
@@ -14160,9 +14191,9 @@ var require_gt = __commonJS({
   }
 });
 
-// node_modules/semver/functions/lt.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lt.js
 var require_lt = __commonJS({
-  "node_modules/semver/functions/lt.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lt.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var lt = (a, b, loose) => compare(a, b, loose) < 0;
@@ -14170,9 +14201,9 @@ var require_lt = __commonJS({
   }
 });
 
-// node_modules/semver/functions/eq.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/eq.js
 var require_eq = __commonJS({
-  "node_modules/semver/functions/eq.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/eq.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var eq = (a, b, loose) => compare(a, b, loose) === 0;
@@ -14180,9 +14211,9 @@ var require_eq = __commonJS({
   }
 });
 
-// node_modules/semver/functions/neq.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/neq.js
 var require_neq = __commonJS({
-  "node_modules/semver/functions/neq.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/neq.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var neq = (a, b, loose) => compare(a, b, loose) !== 0;
@@ -14190,9 +14221,9 @@ var require_neq = __commonJS({
   }
 });
 
-// node_modules/semver/functions/gte.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gte.js
 var require_gte = __commonJS({
-  "node_modules/semver/functions/gte.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gte.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var gte = (a, b, loose) => compare(a, b, loose) >= 0;
@@ -14200,9 +14231,9 @@ var require_gte = __commonJS({
   }
 });
 
-// node_modules/semver/functions/lte.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lte.js
 var require_lte = __commonJS({
-  "node_modules/semver/functions/lte.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lte.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var lte = (a, b, loose) => compare(a, b, loose) <= 0;
@@ -14210,9 +14241,9 @@ var require_lte = __commonJS({
   }
 });
 
-// node_modules/semver/functions/cmp.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/cmp.js
 var require_cmp = __commonJS({
-  "node_modules/semver/functions/cmp.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/cmp.js"(exports2, module2) {
     "use strict";
     var eq = require_eq();
     var neq = require_neq();
@@ -14260,9 +14291,9 @@ var require_cmp = __commonJS({
   }
 });
 
-// node_modules/semver/functions/coerce.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/coerce.js
 var require_coerce = __commonJS({
-  "node_modules/semver/functions/coerce.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/coerce.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var parse = require_parse();
@@ -14306,9 +14337,9 @@ var require_coerce = __commonJS({
   }
 });
 
-// node_modules/semver/internal/lrucache.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/lrucache.js
 var require_lrucache = __commonJS({
-  "node_modules/semver/internal/lrucache.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/lrucache.js"(exports2, module2) {
     "use strict";
     var LRUCache = class {
       constructor() {
@@ -14344,9 +14375,9 @@ var require_lrucache = __commonJS({
   }
 });
 
-// node_modules/semver/classes/range.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/range.js
 var require_range = __commonJS({
-  "node_modules/semver/classes/range.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/range.js"(exports2, module2) {
     "use strict";
     var SPACE_CHARACTERS = /\s+/g;
     var Range = class _Range {
@@ -14517,6 +14548,7 @@ var require_range = __commonJS({
       return result;
     };
     var parseComparator = (comp, options) => {
+      comp = comp.replace(re[t.BUILD], "");
       debug("comp", comp, options);
       comp = replaceCarets(comp, options);
       debug("caret", comp);
@@ -14720,9 +14752,9 @@ var require_range = __commonJS({
   }
 });
 
-// node_modules/semver/classes/comparator.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/comparator.js
 var require_comparator = __commonJS({
-  "node_modules/semver/classes/comparator.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/comparator.js"(exports2, module2) {
     "use strict";
     var ANY = Symbol("SemVer ANY");
     var Comparator = class _Comparator {
@@ -14833,9 +14865,9 @@ var require_comparator = __commonJS({
   }
 });
 
-// node_modules/semver/functions/satisfies.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/satisfies.js
 var require_satisfies = __commonJS({
-  "node_modules/semver/functions/satisfies.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/satisfies.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var satisfies = (version, range, options) => {
@@ -14850,9 +14882,9 @@ var require_satisfies = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/to-comparators.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/to-comparators.js
 var require_to_comparators = __commonJS({
-  "node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var toComparators = (range, options) => new Range(range, options).set.map((comp) => comp.map((c) => c.value).join(" ").trim().split(" "));
@@ -14860,9 +14892,9 @@ var require_to_comparators = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/max-satisfying.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/max-satisfying.js
 var require_max_satisfying = __commonJS({
-  "node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -14889,9 +14921,9 @@ var require_max_satisfying = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/min-satisfying.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-satisfying.js
 var require_min_satisfying = __commonJS({
-  "node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -14918,9 +14950,9 @@ var require_min_satisfying = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/min-version.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-version.js
 var require_min_version = __commonJS({
-  "node_modules/semver/ranges/min-version.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-version.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -14977,9 +15009,9 @@ var require_min_version = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/valid.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/valid.js
 var require_valid2 = __commonJS({
-  "node_modules/semver/ranges/valid.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/valid.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var validRange = (range, options) => {
@@ -14993,9 +15025,9 @@ var require_valid2 = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/outside.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/outside.js
 var require_outside = __commonJS({
-  "node_modules/semver/ranges/outside.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/outside.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Comparator = require_comparator();
@@ -15062,9 +15094,9 @@ var require_outside = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/gtr.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/gtr.js
 var require_gtr = __commonJS({
-  "node_modules/semver/ranges/gtr.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/gtr.js"(exports2, module2) {
     "use strict";
     var outside = require_outside();
     var gtr = (version, range, options) => outside(version, range, ">", options);
@@ -15072,9 +15104,9 @@ var require_gtr = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/ltr.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/ltr.js
 var require_ltr = __commonJS({
-  "node_modules/semver/ranges/ltr.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/ltr.js"(exports2, module2) {
     "use strict";
     var outside = require_outside();
     var ltr = (version, range, options) => outside(version, range, "<", options);
@@ -15082,9 +15114,9 @@ var require_ltr = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/intersects.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/intersects.js
 var require_intersects = __commonJS({
-  "node_modules/semver/ranges/intersects.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/intersects.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var intersects = (r1, r2, options) => {
@@ -15096,9 +15128,9 @@ var require_intersects = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/simplify.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/simplify.js
 var require_simplify = __commonJS({
-  "node_modules/semver/ranges/simplify.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/simplify.js"(exports2, module2) {
     "use strict";
     var satisfies = require_satisfies();
     var compare = require_compare();
@@ -15146,9 +15178,9 @@ var require_simplify = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/subset.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/subset.js
 var require_subset = __commonJS({
-  "node_modules/semver/ranges/subset.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/subset.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var Comparator = require_comparator();
@@ -15308,9 +15340,9 @@ var require_subset = __commonJS({
   }
 });
 
-// node_modules/semver/index.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/index.js
 var require_semver2 = __commonJS({
-  "node_modules/semver/index.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/index.js"(exports2, module2) {
     "use strict";
     var internalRe = require_re();
     var constants = require_constants();
@@ -15403,25 +15435,25 @@ var require_semver2 = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js
 var require_asymmetricKeyDetailsSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, ">=15.7.0");
   }
 });
 
-// node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js
 var require_rsaPssKeyDetailsSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, ">=16.9.0");
   }
 });
 
-// node_modules/jsonwebtoken/lib/validateAsymmetricKey.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/validateAsymmetricKey.js
 var require_validateAsymmetricKey = __commonJS({
-  "node_modules/jsonwebtoken/lib/validateAsymmetricKey.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/validateAsymmetricKey.js"(exports2, module2) {
     var ASYMMETRIC_KEY_DETAILS_SUPPORTED = require_asymmetricKeyDetailsSupported();
     var RSA_PSS_KEY_DETAILS_SUPPORTED = require_rsaPssKeyDetailsSupported();
     var allowedAlgorithmsForKeys = {
@@ -15472,17 +15504,17 @@ var require_validateAsymmetricKey = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/psSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/psSupported.js
 var require_psSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/psSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/psSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, "^6.12.0 || >=8.0.0");
   }
 });
 
-// node_modules/jsonwebtoken/verify.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/verify.js
 var require_verify = __commonJS({
-  "node_modules/jsonwebtoken/verify.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/verify.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var NotBeforeError = require_NotBeforeError();
     var TokenExpiredError = require_TokenExpiredError();
@@ -15695,9 +15727,9 @@ var require_verify = __commonJS({
   }
 });
 
-// node_modules/lodash.includes/index.js
+// node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes/index.js
 var require_lodash = __commonJS({
-  "node_modules/lodash.includes/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes/index.js"(exports2, module2) {
     var INFINITY = 1 / 0;
     var MAX_SAFE_INTEGER = 9007199254740991;
     var MAX_INTEGER = 17976931348623157e292;
@@ -15879,9 +15911,9 @@ var require_lodash = __commonJS({
   }
 });
 
-// node_modules/lodash.isboolean/index.js
+// node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean/index.js
 var require_lodash2 = __commonJS({
-  "node_modules/lodash.isboolean/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean/index.js"(exports2, module2) {
     var boolTag = "[object Boolean]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -15895,9 +15927,9 @@ var require_lodash2 = __commonJS({
   }
 });
 
-// node_modules/lodash.isinteger/index.js
+// node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger/index.js
 var require_lodash3 = __commonJS({
-  "node_modules/lodash.isinteger/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger/index.js"(exports2, module2) {
     var INFINITY = 1 / 0;
     var MAX_INTEGER = 17976931348623157e292;
     var NAN = 0 / 0;
@@ -15959,9 +15991,9 @@ var require_lodash3 = __commonJS({
   }
 });
 
-// node_modules/lodash.isnumber/index.js
+// node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber/index.js
 var require_lodash4 = __commonJS({
-  "node_modules/lodash.isnumber/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber/index.js"(exports2, module2) {
     var numberTag = "[object Number]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -15975,9 +16007,9 @@ var require_lodash4 = __commonJS({
   }
 });
 
-// node_modules/lodash.isplainobject/index.js
+// node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject/index.js
 var require_lodash5 = __commonJS({
-  "node_modules/lodash.isplainobject/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject/index.js"(exports2, module2) {
     var objectTag = "[object Object]";
     function isHostObject(value) {
       var result = false;
@@ -16019,9 +16051,9 @@ var require_lodash5 = __commonJS({
   }
 });
 
-// node_modules/lodash.isstring/index.js
+// node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring/index.js
 var require_lodash6 = __commonJS({
-  "node_modules/lodash.isstring/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring/index.js"(exports2, module2) {
     var stringTag = "[object String]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -16036,9 +16068,9 @@ var require_lodash6 = __commonJS({
   }
 });
 
-// node_modules/lodash.once/index.js
+// node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once/index.js
 var require_lodash7 = __commonJS({
-  "node_modules/lodash.once/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once/index.js"(exports2, module2) {
     var FUNC_ERROR_TEXT = "Expected a function";
     var INFINITY = 1 / 0;
     var MAX_INTEGER = 17976931348623157e292;
@@ -16117,9 +16149,9 @@ var require_lodash7 = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/sign.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/sign.js
 var require_sign = __commonJS({
-  "node_modules/jsonwebtoken/sign.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/sign.js"(exports2, module2) {
     var timespan = require_timespan();
     var PS_SUPPORTED = require_psSupported();
     var validateAsymmetricKey = require_validateAsymmetricKey();
@@ -16342,9 +16374,9 @@ var require_sign = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/index.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/index.js
 var require_jsonwebtoken = __commonJS({
-  "node_modules/jsonwebtoken/index.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/index.js"(exports2, module2) {
     module2.exports = {
       decode: require_decode(),
       verify: require_verify(),
@@ -16356,7 +16388,7 @@ var require_jsonwebtoken = __commonJS({
   }
 });
 
-// node_modules/@stainless-api/sdk/internal/tslib.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/tslib.mjs
 function __classPrivateFieldSet(receiver, state, value, kind, f) {
   if (kind === "m")
     throw new TypeError("Private method is not writable");
@@ -16374,7 +16406,7 @@ function __classPrivateFieldGet(receiver, state, kind, f) {
   return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 }
 
-// node_modules/@stainless-api/sdk/internal/utils/uuid.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/uuid.mjs
 var uuid4 = function() {
   const { crypto: crypto2 } = globalThis;
   if (crypto2?.randomUUID) {
@@ -16386,7 +16418,7 @@ var uuid4 = function() {
   return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) => (+c ^ randomByte() & 15 >> +c / 4).toString(16));
 };
 
-// node_modules/@stainless-api/sdk/internal/errors.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/errors.mjs
 function isAbortError(err) {
   return typeof err === "object" && err !== null && // Spec-compliant fetch implementations
   ("name" in err && err.name === "AbortError" || // Expo fetch
@@ -16417,7 +16449,7 @@ var castToError = (err) => {
   return new Error(err);
 };
 
-// node_modules/@stainless-api/sdk/core/error.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/error.mjs
 var StainlessError = class extends Error {
 };
 var APIError = class _APIError extends StainlessError {
@@ -16506,7 +16538,7 @@ var RateLimitError = class extends APIError {
 var InternalServerError = class extends APIError {
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/values.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/values.mjs
 var startsWithSchemeRegexp = /^[a-z][a-z0-9+.-]*:/i;
 var isAbsoluteURL = (url) => {
   return startsWithSchemeRegexp.test(url);
@@ -16546,13 +16578,13 @@ var safeJSON = (text) => {
   }
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/sleep.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/sleep.mjs
 var sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-// node_modules/@stainless-api/sdk/version.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/version.mjs
 var VERSION = "0.1.0-alpha.19";
 
-// node_modules/@stainless-api/sdk/internal/detect-platform.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/detect-platform.mjs
 function getDetectedPlatform() {
   if (typeof Deno !== "undefined" && Deno.build != null) {
     return "deno";
@@ -16678,7 +16710,7 @@ var getPlatformHeaders = () => {
   return _platformHeaders ?? (_platformHeaders = getPlatformProperties());
 };
 
-// node_modules/@stainless-api/sdk/internal/shims.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/shims.mjs
 function getDefaultFetch() {
   if (typeof fetch !== "undefined") {
     return fetch;
@@ -16723,7 +16755,7 @@ async function CancelReadableStream(stream) {
   await cancelPromise;
 }
 
-// node_modules/@stainless-api/sdk/internal/request-options.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/request-options.mjs
 var FallbackEncoder = ({ headers, body }) => {
   return {
     bodyHeaders: {
@@ -16733,7 +16765,7 @@ var FallbackEncoder = ({ headers, body }) => {
   };
 };
 
-// node_modules/@stainless-api/sdk/internal/qs/formats.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/qs/formats.mjs
 var default_format = "RFC3986";
 var default_formatter = (v) => String(v);
 var formatters = {
@@ -16742,7 +16774,7 @@ var formatters = {
 };
 var RFC1738 = "RFC1738";
 
-// node_modules/@stainless-api/sdk/internal/qs/utils.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/qs/utils.mjs
 var has = (obj, key) => (has = Object.hasOwn ?? Function.prototype.call.bind(Object.prototype.hasOwnProperty), has(obj, key));
 var hex_table = /* @__PURE__ */ (() => {
   const array = [];
@@ -16821,7 +16853,7 @@ function maybe_map(val, fn) {
   return fn(val);
 }
 
-// node_modules/@stainless-api/sdk/internal/qs/stringify.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/qs/stringify.mjs
 var array_prefix_generators = {
   brackets(prefix) {
     return String(prefix) + "[]";
@@ -17099,7 +17131,7 @@ function stringify(object, opts = {}) {
   return joined.length > 0 ? prefix + joined : "";
 }
 
-// node_modules/@stainless-api/sdk/internal/utils/log.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/log.mjs
 var levelNumbers = {
   off: 0,
   error: 200,
@@ -17172,7 +17204,7 @@ var formatRequestDetails = (details) => {
   return details;
 };
 
-// node_modules/@stainless-api/sdk/internal/parse.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/parse.mjs
 async function defaultParseResponse(client, props) {
   const { response, requestLogID, retryOfRequestLogID, startTime } = props;
   const body = await (async () => {
@@ -17202,7 +17234,7 @@ async function defaultParseResponse(client, props) {
   return body;
 }
 
-// node_modules/@stainless-api/sdk/core/api-promise.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/api-promise.mjs
 var _APIPromise_client;
 var APIPromise = class _APIPromise extends Promise {
   constructor(client, responsePromise, parseResponse = defaultParseResponse) {
@@ -17263,7 +17295,7 @@ var APIPromise = class _APIPromise extends Promise {
 };
 _APIPromise_client = /* @__PURE__ */ new WeakMap();
 
-// node_modules/@stainless-api/sdk/core/pagination.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/pagination.mjs
 var _AbstractPage_client;
 var AbstractPage = class {
   constructor(client, response, body, options) {
@@ -17344,7 +17376,7 @@ var Page = class extends AbstractPage {
   }
 };
 
-// node_modules/@stainless-api/sdk/internal/uploads.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/uploads.mjs
 var checkFileSupport = () => {
   if (typeof File === "undefined") {
     const { process: process7 } = globalThis;
@@ -17361,7 +17393,7 @@ function getName(value) {
 }
 var isAsyncIterable = (value) => value != null && typeof value === "object" && typeof value[Symbol.asyncIterator] === "function";
 
-// node_modules/@stainless-api/sdk/internal/to-file.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/to-file.mjs
 var isBlobLike = (value) => value != null && typeof value === "object" && typeof value.size === "number" && typeof value.type === "string" && typeof value.text === "function" && typeof value.slice === "function" && typeof value.arrayBuffer === "function";
 var isFileLike = (value) => value != null && typeof value === "object" && typeof value.name === "string" && typeof value.lastModified === "number" && isBlobLike(value);
 var isResponseLike = (value) => value != null && typeof value === "object" && typeof value.url === "string" && typeof value.blob === "function";
@@ -17413,14 +17445,14 @@ function propsForError(value) {
   return `; props: [${props.map((p) => `"${p}"`).join(", ")}]`;
 }
 
-// node_modules/@stainless-api/sdk/core/resource.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/resource.mjs
 var APIResource = class {
   constructor(client) {
     this._client = client;
   }
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/path.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/path.mjs
 function encodeURIPath(str) {
   return str.replace(/[^A-Za-z0-9\-._~!$&'()*+,;=:@]+/g, encodeURIComponent);
 }
@@ -17475,7 +17507,7 @@ ${underline}`);
 };
 var path = /* @__PURE__ */ createPathTagFunction(encodeURIPath);
 
-// node_modules/@stainless-api/sdk/resources/builds/diagnostics.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/builds/diagnostics.mjs
 var Diagnostics = class extends APIResource {
   /**
    * Get the list of diagnostics for a given build.
@@ -17491,7 +17523,7 @@ var Diagnostics = class extends APIResource {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/builds/target-outputs.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/builds/target-outputs.mjs
 var TargetOutputs = class extends APIResource {
   /**
    * Retrieve a method to download an output for a given build target.
@@ -17510,7 +17542,7 @@ var TargetOutputs = class extends APIResource {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/builds/builds.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/builds/builds.mjs
 var Builds = class extends APIResource {
   constructor() {
     super(...arguments);
@@ -17562,7 +17594,7 @@ var Builds = class extends APIResource {
 Builds.Diagnostics = Diagnostics;
 Builds.TargetOutputs = TargetOutputs;
 
-// node_modules/@stainless-api/sdk/resources/orgs.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/orgs.mjs
 var Orgs = class extends APIResource {
   /**
    * Retrieve an organization by name.
@@ -17578,7 +17610,7 @@ var Orgs = class extends APIResource {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/projects/branches.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/projects/branches.mjs
 var Branches = class extends APIResource {
   /**
    * Create a new branch for a project.
@@ -17643,7 +17675,7 @@ var Branches = class extends APIResource {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/projects/configs.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/projects/configs.mjs
 var Configs = class extends APIResource {
   /**
    * Retrieve the configuration files for a given project.
@@ -17661,7 +17693,7 @@ var Configs = class extends APIResource {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/projects/projects.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/projects/projects.mjs
 var Projects = class extends APIResource {
   constructor() {
     super(...arguments);
@@ -17698,7 +17730,7 @@ var Projects = class extends APIResource {
 Projects.Branches = Branches;
 Projects.Configs = Configs;
 
-// node_modules/@stainless-api/sdk/internal/headers.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/headers.mjs
 var brand_privateNullableHeaders = /* @__PURE__ */ Symbol("brand.privateNullableHeaders");
 function* iterateHeaders(headers) {
   if (!headers)
@@ -17761,7 +17793,7 @@ var buildHeaders = (newHeaders) => {
   return { [brand_privateNullableHeaders]: true, values: targetHeaders, nulls: nullHeaders };
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/env.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/env.mjs
 var readEnv = (env) => {
   if (typeof globalThis.process !== "undefined") {
     return globalThis.process.env?.[env]?.trim() ?? void 0;
@@ -17772,7 +17804,7 @@ var readEnv = (env) => {
   return void 0;
 };
 
-// node_modules/@stainless-api/sdk/lib/unwrap.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/lib/unwrap.mjs
 async function unwrapFile(value) {
   if (value === null) {
     return null;
@@ -17784,7 +17816,7 @@ async function unwrapFile(value) {
   return response.text();
 }
 
-// node_modules/@stainless-api/sdk/client.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/client.mjs
 var _Stainless_instances;
 var _a;
 var _Stainless_encoder;
@@ -18410,10 +18442,10 @@ function makeCommitMessageConventional(message) {
   return message;
 }
 
-// node_modules/@stainless-api/github-internal/lib/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/lib/secrets.mjs
 var import_libsodium_wrappers = __toESM(require_libsodium_wrappers(), 1);
 
-// node_modules/@stainless-api/github-internal/lib/auth.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/lib/auth.mjs
 var import_jsonwebtoken = __toESM(require_jsonwebtoken(), 1);
 
 // src/compat/output.ts
@@ -18480,7 +18512,7 @@ async function getStainlessAuth() {
   }
 }
 
-// node_modules/nano-spawn/source/context.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/context.js
 var import_node_process = __toESM(require("node:process"), 1);
 var import_node_util = require("node:util");
 var getContext = (raw) => ({
@@ -18490,7 +18522,7 @@ var getContext = (raw) => ({
 });
 var getCommandPart = (part) => /[^\w./-]/.test(part) ? `'${part.replaceAll("'", "'\\''")}'` : part;
 
-// node_modules/nano-spawn/source/options.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/options.js
 var import_node_path = __toESM(require("node:path"), 1);
 var import_node_url = require("node:url");
 var import_node_process2 = __toESM(require("node:process"), 1);
@@ -18522,12 +18554,12 @@ var addLocalPath = ({ Path = "", PATH = Path, ...env }, cwd) => {
 };
 var getLocalPaths = (localPaths, localPath) => localPaths.at(-1) === localPath ? localPaths : getLocalPaths([...localPaths, localPath], import_node_path.default.resolve(localPath, ".."));
 
-// node_modules/nano-spawn/source/spawn.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/spawn.js
 var import_node_child_process = require("node:child_process");
 var import_node_events2 = require("node:events");
 var import_node_process5 = __toESM(require("node:process"), 1);
 
-// node_modules/nano-spawn/source/windows.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/windows.js
 var import_promises = __toESM(require("node:fs/promises"), 1);
 var import_node_path2 = __toESM(require("node:path"), 1);
 var import_node_process3 = __toESM(require("node:process"), 1);
@@ -18561,7 +18593,7 @@ var exeExtensions = [".exe", ".com"];
 var escapeArgument = (argument) => escapeFile(escapeFile(`"${argument.replaceAll(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1")}"`));
 var escapeFile = (file) => file.replaceAll(/([()\][%!^"`<>&|;, *?])/g, "^$1");
 
-// node_modules/nano-spawn/source/result.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/result.js
 var import_node_events = require("node:events");
 var import_node_process4 = __toESM(require("node:process"), 1);
 var getResult = async (nodeChildProcess, { input }, context) => {
@@ -18620,7 +18652,7 @@ var getOutputs = ({ state: { stdout, stderr, output }, command, start }) => ({
 });
 var getOutput = (output) => output.at(-1) === "\n" ? output.slice(0, output.at(-2) === "\r" ? -2 : -1) : output;
 
-// node_modules/nano-spawn/source/spawn.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/spawn.js
 var spawnSubprocess = async (file, commandArguments, options, context) => {
   try {
     if (["node", "node.exe"].includes(file.toLowerCase())) {
@@ -18654,7 +18686,7 @@ var bufferOutput = (stream, { state }, streamName) => {
   }
 };
 
-// node_modules/nano-spawn/source/pipe.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/pipe.js
 var import_promises2 = require("node:stream/promises");
 var handlePipe = async (subprocesses) => {
   const [[from, to]] = await Promise.all([Promise.allSettled(subprocesses), pipeStreams(subprocesses)]);
@@ -18688,7 +18720,7 @@ var closeStdin = async (nodeChildProcess) => {
   stdin.end();
 };
 
-// node_modules/nano-spawn/source/iterable.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/iterable.js
 var readline = __toESM(require("node:readline/promises"), 1);
 var lineIterator = async function* (subprocess, { state }, streamName) {
   if (state.isIterating === false) {
@@ -18738,7 +18770,7 @@ var getNext = async (iterator) => {
   }
 };
 
-// node_modules/nano-spawn/source/index.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/index.js
 function spawn2(file, second, third, previous) {
   const [commandArguments = [], options = {}] = Array.isArray(second) ? [second, third] : [[], second];
   const context = getContext([file, ...commandArguments]);
@@ -18829,7 +18861,7 @@ async function readConfig({
   return results;
 }
 
-// node_modules/diff/libesm/diff/base.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/diff/base.js
 var Diff = class {
   diff(oldStr, newStr, options = {}) {
     let callback;
@@ -19031,7 +19063,7 @@ var Diff = class {
   }
 };
 
-// node_modules/diff/libesm/util/string.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/util/string.js
 function hasOnlyWinLineEndings(string) {
   return string.includes("\r\n") && !string.startsWith("\n") && !string.match(/[^\r]\n/);
 }
@@ -19039,7 +19071,7 @@ function hasOnlyUnixLineEndings(string) {
   return !string.includes("\r\n") && string.includes("\n");
 }
 
-// node_modules/diff/libesm/diff/line.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/diff/line.js
 var LineDiff = class extends Diff {
   constructor() {
     super(...arguments);
@@ -19087,7 +19119,7 @@ function tokenize(value, options) {
   return retLines;
 }
 
-// node_modules/diff/libesm/patch/line-endings.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/patch/line-endings.js
 function unixToWin(patch) {
   if (Array.isArray(patch)) {
     return patch.map((p) => unixToWin(p));
@@ -19119,7 +19151,7 @@ function isWin(patch) {
   })));
 }
 
-// node_modules/diff/libesm/patch/parse.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/patch/parse.js
 function parsePatch(uniDiff) {
   const diffstr = uniDiff.split(/\n/), list = [];
   let i = 0;
@@ -19224,7 +19256,7 @@ function parsePatch(uniDiff) {
   return list;
 }
 
-// node_modules/diff/libesm/util/distance-iterator.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/util/distance-iterator.js
 function distance_iterator_default(start, minLine, maxLine) {
   let wantForward = true, backwardExhausted = false, forwardExhausted = false, localOffset = 1;
   return function iterator() {
@@ -19253,7 +19285,7 @@ function distance_iterator_default(start, minLine, maxLine) {
   };
 }
 
-// node_modules/diff/libesm/patch/apply.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/patch/apply.js
 function applyPatch(source, patch, options = {}) {
   let patches;
   if (typeof patch === "string") {
@@ -19402,7 +19434,7 @@ function applyStructuredPatch(source, patch, options = {}) {
   return resultLines.join("\n");
 }
 
-// node_modules/diff/libesm/patch/create.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/patch/create.js
 var INCLUDE_HEADERS = {
   includeIndex: true,
   includeUnderline: true,
@@ -19585,6 +19617,30 @@ function splitLines(text) {
   return result;
 }
 
+// src/resolve.ts
+async function resolveProject(client, projectInput) {
+  if (projectInput) {
+    return { projectName: projectInput, orgName: void 0 };
+  }
+  const page = await client.projects.list({ limit: 6 });
+  const projects = page.data;
+  if (projects.length === 0) {
+    throw new Error(
+      "No projects found for the given API key. Please specify the `project` input explicitly."
+    );
+  }
+  if (projects.length === 1) {
+    const project = projects[0];
+    logger.info(`Auto-detected project: ${project.slug}`);
+    return { projectName: project.slug, orgName: project.org };
+  }
+  const slugs = projects.slice(0, 5).map((p) => p.slug).join(", ");
+  const suffix = projects.length > 5 ? ", ..." : "";
+  throw new Error(
+    `Multiple projects found: ${slugs}${suffix}. Please specify the \`project\` input explicitly.`
+  );
+}
+
 // package.json
 var package_default = {
   name: "upload-openapi-spec-action",
@@ -19670,18 +19726,23 @@ function wrapAction(actionType, fn) {
   return async () => {
     let stainless;
     let projectName;
+    let orgName;
     try {
-      projectName = getInput("project", { required: true });
+      const projectInput = getInput("project", { required: false }) || void 0;
       const auth = await getStainlessAuth();
-      stainless = getStainlessClient(actionType, {
-        project: projectName,
+      const client = getStainlessClient(actionType, {
         apiKey: auth.key,
         logLevel: "warn",
         fetch: createAutoRefreshFetch(auth, getStainlessAuth)
       });
-      await fn(stainless);
+      const resolved = await resolveProject(client, projectInput);
+      projectName = resolved.projectName;
+      stainless = client.withOptions({ project: projectName });
+      orgName = getInput("org", { required: false }) || resolved.orgName;
+      await fn({ stainless, projectName, orgName });
       await maybeReportResult({
         stainless,
+        orgName,
         projectName,
         actionType,
         successOrError: { result: "success" }
@@ -19691,6 +19752,7 @@ function wrapAction(actionType, fn) {
       if (stainless) {
         await maybeReportResult({
           stainless,
+          orgName,
           projectName,
           actionType,
           successOrError: serializeError(error)
@@ -19711,6 +19773,7 @@ function serializeError(error) {
 }
 async function maybeReportResult({
   stainless,
+  orgName,
   projectName,
   actionType,
   successOrError
@@ -19720,6 +19783,7 @@ async function maybeReportResult({
   }
   try {
     const body = {
+      org: orgName,
       project: projectName,
       build_ids: [...accumulatedBuildIds],
       action_type: actionType,
@@ -20066,11 +20130,11 @@ async function* pollBuild({
 }
 
 // src/build.ts
-var main = wrapAction("build", async (stainless) => {
+var main = wrapAction("build", async (ctx) => {
+  const { stainless, projectName } = ctx;
   try {
     const oasPath = getInput("oas_path", { required: false }) || void 0;
     const configPath = getInput("config_path", { required: false }) || void 0;
-    const projectName = getInput("project", { required: true });
     const commitMessage = makeCommitMessageConventional(
       getInput("commit_message", { required: false }) || void 0
     );

--- a/dist/checkoutPRRef.js
+++ b/dist/checkoutPRRef.js
@@ -25,9 +25,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/libsodium/dist/modules/libsodium.js
+// node_modules/.pnpm/libsodium@0.7.15/node_modules/libsodium/dist/modules/libsodium.js
 var require_libsodium = __commonJS({
-  "node_modules/libsodium/dist/modules/libsodium.js"(exports2, module2) {
+  "node_modules/.pnpm/libsodium@0.7.15/node_modules/libsodium/dist/modules/libsodium.js"(exports2, module2) {
     !(function(A) {
       function I(A2) {
         "use strict";
@@ -2631,9 +2631,9 @@ var require_libsodium = __commonJS({
   }
 });
 
-// node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js
+// node_modules/.pnpm/libsodium-wrappers@0.7.15/node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js
 var require_libsodium_wrappers = __commonJS({
-  "node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js"(exports2) {
+  "node_modules/.pnpm/libsodium-wrappers@0.7.15/node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js"(exports2) {
     !(function(e) {
       function a(e2, a2) {
         "use strict";
@@ -5234,9 +5234,9 @@ var require_libsodium_wrappers = __commonJS({
   }
 });
 
-// node_modules/safe-buffer/index.js
+// node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer/index.js
 var require_safe_buffer = __commonJS({
-  "node_modules/safe-buffer/index.js"(exports2, module2) {
+  "node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer/index.js"(exports2, module2) {
     var buffer = require("buffer");
     var Buffer2 = buffer.Buffer;
     function copyProps(src, dst) {
@@ -5292,9 +5292,9 @@ var require_safe_buffer = __commonJS({
   }
 });
 
-// node_modules/jws/lib/data-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/data-stream.js
 var require_data_stream = __commonJS({
-  "node_modules/jws/lib/data-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/data-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var Stream = require("stream");
     var util = require("util");
@@ -5340,9 +5340,9 @@ var require_data_stream = __commonJS({
   }
 });
 
-// node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js
+// node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js
 var require_param_bytes_for_alg = __commonJS({
-  "node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js"(exports2, module2) {
+  "node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js"(exports2, module2) {
     "use strict";
     function getParamSize(keySize) {
       var result = (keySize / 8 | 0) + (keySize % 8 === 0 ? 0 : 1);
@@ -5364,9 +5364,9 @@ var require_param_bytes_for_alg = __commonJS({
   }
 });
 
-// node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js
+// node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js
 var require_ecdsa_sig_formatter = __commonJS({
-  "node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js"(exports2, module2) {
+  "node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js"(exports2, module2) {
     "use strict";
     var Buffer2 = require_safe_buffer().Buffer;
     var getParamBytesForAlg = require_param_bytes_for_alg();
@@ -5504,9 +5504,9 @@ var require_ecdsa_sig_formatter = __commonJS({
   }
 });
 
-// node_modules/buffer-equal-constant-time/index.js
+// node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time/index.js
 var require_buffer_equal_constant_time = __commonJS({
-  "node_modules/buffer-equal-constant-time/index.js"(exports2, module2) {
+  "node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time/index.js"(exports2, module2) {
     "use strict";
     var Buffer2 = require("buffer").Buffer;
     var SlowBuffer = require("buffer").SlowBuffer;
@@ -5538,9 +5538,9 @@ var require_buffer_equal_constant_time = __commonJS({
   }
 });
 
-// node_modules/jwa/index.js
+// node_modules/.pnpm/jwa@2.0.1/node_modules/jwa/index.js
 var require_jwa = __commonJS({
-  "node_modules/jwa/index.js"(exports2, module2) {
+  "node_modules/.pnpm/jwa@2.0.1/node_modules/jwa/index.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var crypto = require("crypto");
     var formatEcdsa = require_ecdsa_sig_formatter();
@@ -5749,7 +5749,7 @@ var require_jwa = __commonJS({
         es: createECDSAVerifer,
         none: createNoneVerifier
       };
-      var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/i);
+      var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/);
       if (!match)
         throw typeError(MSG_INVALID_ALGORITHM, algorithm);
       var algo = (match[1] || match[3]).toLowerCase();
@@ -5762,9 +5762,9 @@ var require_jwa = __commonJS({
   }
 });
 
-// node_modules/jws/lib/tostring.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/tostring.js
 var require_tostring = __commonJS({
-  "node_modules/jws/lib/tostring.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/tostring.js"(exports2, module2) {
     var Buffer2 = require("buffer").Buffer;
     module2.exports = function toString(obj) {
       if (typeof obj === "string")
@@ -5776,9 +5776,9 @@ var require_tostring = __commonJS({
   }
 });
 
-// node_modules/jws/lib/sign-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/sign-stream.js
 var require_sign_stream = __commonJS({
-  "node_modules/jws/lib/sign-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/sign-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var DataStream = require_data_stream();
     var jwa = require_jwa();
@@ -5805,7 +5805,12 @@ var require_sign_stream = __commonJS({
       return util.format("%s.%s", securedInput, signature);
     }
     function SignStream(opts) {
-      var secret = opts.secret || opts.privateKey || opts.key;
+      var secret = opts.secret;
+      secret = secret == null ? opts.privateKey : secret;
+      secret = secret == null ? opts.key : secret;
+      if (/^hs/i.test(opts.header.alg) === true && secret == null) {
+        throw new TypeError("secret must be a string or buffer or a KeyObject");
+      }
       var secretStream = new DataStream(secret);
       this.readable = true;
       this.header = opts.header;
@@ -5846,9 +5851,9 @@ var require_sign_stream = __commonJS({
   }
 });
 
-// node_modules/jws/lib/verify-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/verify-stream.js
 var require_verify_stream = __commonJS({
-  "node_modules/jws/lib/verify-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/verify-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var DataStream = require_data_stream();
     var jwa = require_jwa();
@@ -5917,7 +5922,12 @@ var require_verify_stream = __commonJS({
     }
     function VerifyStream(opts) {
       opts = opts || {};
-      var secretOrKey = opts.secret || opts.publicKey || opts.key;
+      var secretOrKey = opts.secret;
+      secretOrKey = secretOrKey == null ? opts.publicKey : secretOrKey;
+      secretOrKey = secretOrKey == null ? opts.key : secretOrKey;
+      if (/^hs/i.test(opts.algorithm) === true && secretOrKey == null) {
+        throw new TypeError("secret must be a string or buffer or a KeyObject");
+      }
       var secretStream = new DataStream(secretOrKey);
       this.readable = true;
       this.algorithm = opts.algorithm;
@@ -5956,9 +5966,9 @@ var require_verify_stream = __commonJS({
   }
 });
 
-// node_modules/jws/index.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/index.js
 var require_jws = __commonJS({
-  "node_modules/jws/index.js"(exports2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/index.js"(exports2) {
     var SignStream = require_sign_stream();
     var VerifyStream = require_verify_stream();
     var ALGORITHMS = [
@@ -5989,9 +5999,9 @@ var require_jws = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/decode.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/decode.js
 var require_decode = __commonJS({
-  "node_modules/jsonwebtoken/decode.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/decode.js"(exports2, module2) {
     var jws = require_jws();
     module2.exports = function(jwt, options) {
       options = options || {};
@@ -6021,9 +6031,9 @@ var require_decode = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/JsonWebTokenError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/JsonWebTokenError.js
 var require_JsonWebTokenError = __commonJS({
-  "node_modules/jsonwebtoken/lib/JsonWebTokenError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/JsonWebTokenError.js"(exports2, module2) {
     var JsonWebTokenError = function(message, error) {
       Error.call(this, message);
       if (Error.captureStackTrace) {
@@ -6039,9 +6049,9 @@ var require_JsonWebTokenError = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/NotBeforeError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/NotBeforeError.js
 var require_NotBeforeError = __commonJS({
-  "node_modules/jsonwebtoken/lib/NotBeforeError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/NotBeforeError.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var NotBeforeError = function(message, date) {
       JsonWebTokenError.call(this, message);
@@ -6054,9 +6064,9 @@ var require_NotBeforeError = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/TokenExpiredError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/TokenExpiredError.js
 var require_TokenExpiredError = __commonJS({
-  "node_modules/jsonwebtoken/lib/TokenExpiredError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/TokenExpiredError.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var TokenExpiredError = function(message, expiredAt) {
       JsonWebTokenError.call(this, message);
@@ -6069,9 +6079,9 @@ var require_TokenExpiredError = __commonJS({
   }
 });
 
-// node_modules/ms/index.js
+// node_modules/.pnpm/ms@2.1.3/node_modules/ms/index.js
 var require_ms = __commonJS({
-  "node_modules/ms/index.js"(exports2, module2) {
+  "node_modules/.pnpm/ms@2.1.3/node_modules/ms/index.js"(exports2, module2) {
     var s = 1e3;
     var m = s * 60;
     var h = m * 60;
@@ -6185,9 +6195,9 @@ var require_ms = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/timespan.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/timespan.js
 var require_timespan = __commonJS({
-  "node_modules/jsonwebtoken/lib/timespan.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/timespan.js"(exports2, module2) {
     var ms = require_ms();
     module2.exports = function(time, iat) {
       var timestamp = iat || Math.floor(Date.now() / 1e3);
@@ -6206,9 +6216,9 @@ var require_timespan = __commonJS({
   }
 });
 
-// node_modules/semver/internal/constants.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/constants.js
 var require_constants = __commonJS({
-  "node_modules/semver/internal/constants.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/constants.js"(exports2, module2) {
     "use strict";
     var SEMVER_SPEC_VERSION = "2.0.0";
     var MAX_LENGTH = 256;
@@ -6238,9 +6248,9 @@ var require_constants = __commonJS({
   }
 });
 
-// node_modules/semver/internal/debug.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/debug.js
 var require_debug = __commonJS({
-  "node_modules/semver/internal/debug.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/debug.js"(exports2, module2) {
     "use strict";
     var debug = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
     };
@@ -6248,9 +6258,9 @@ var require_debug = __commonJS({
   }
 });
 
-// node_modules/semver/internal/re.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/re.js
 var require_re = __commonJS({
-  "node_modules/semver/internal/re.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/re.js"(exports2, module2) {
     "use strict";
     var {
       MAX_SAFE_COMPONENT_LENGTH,
@@ -6336,9 +6346,9 @@ var require_re = __commonJS({
   }
 });
 
-// node_modules/semver/internal/parse-options.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/parse-options.js
 var require_parse_options = __commonJS({
-  "node_modules/semver/internal/parse-options.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/parse-options.js"(exports2, module2) {
     "use strict";
     var looseOption = Object.freeze({ loose: true });
     var emptyOpts = Object.freeze({});
@@ -6355,12 +6365,15 @@ var require_parse_options = __commonJS({
   }
 });
 
-// node_modules/semver/internal/identifiers.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/identifiers.js
 var require_identifiers = __commonJS({
-  "node_modules/semver/internal/identifiers.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/identifiers.js"(exports2, module2) {
     "use strict";
     var numeric = /^[0-9]+$/;
     var compareIdentifiers = (a, b) => {
+      if (typeof a === "number" && typeof b === "number") {
+        return a === b ? 0 : a < b ? -1 : 1;
+      }
       const anum = numeric.test(a);
       const bnum = numeric.test(b);
       if (anum && bnum) {
@@ -6377,9 +6390,9 @@ var require_identifiers = __commonJS({
   }
 });
 
-// node_modules/semver/classes/semver.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js
 var require_semver = __commonJS({
-  "node_modules/semver/classes/semver.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js"(exports2, module2) {
     "use strict";
     var debug = require_debug();
     var { MAX_LENGTH, MAX_SAFE_INTEGER } = require_constants();
@@ -6467,7 +6480,25 @@ var require_semver = __commonJS({
         if (!(other instanceof _SemVer)) {
           other = new _SemVer(other, this.options);
         }
-        return compareIdentifiers(this.major, other.major) || compareIdentifiers(this.minor, other.minor) || compareIdentifiers(this.patch, other.patch);
+        if (this.major < other.major) {
+          return -1;
+        }
+        if (this.major > other.major) {
+          return 1;
+        }
+        if (this.minor < other.minor) {
+          return -1;
+        }
+        if (this.minor > other.minor) {
+          return 1;
+        }
+        if (this.patch < other.patch) {
+          return -1;
+        }
+        if (this.patch > other.patch) {
+          return 1;
+        }
+        return 0;
       }
       comparePre(other) {
         if (!(other instanceof _SemVer)) {
@@ -6638,9 +6669,9 @@ var require_semver = __commonJS({
   }
 });
 
-// node_modules/semver/functions/parse.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/parse.js
 var require_parse = __commonJS({
-  "node_modules/semver/functions/parse.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/parse.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var parse = (version, options, throwErrors = false) => {
@@ -6660,9 +6691,9 @@ var require_parse = __commonJS({
   }
 });
 
-// node_modules/semver/functions/valid.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/valid.js
 var require_valid = __commonJS({
-  "node_modules/semver/functions/valid.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/valid.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var valid = (version, options) => {
@@ -6673,9 +6704,9 @@ var require_valid = __commonJS({
   }
 });
 
-// node_modules/semver/functions/clean.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/clean.js
 var require_clean = __commonJS({
-  "node_modules/semver/functions/clean.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/clean.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var clean = (version, options) => {
@@ -6686,9 +6717,9 @@ var require_clean = __commonJS({
   }
 });
 
-// node_modules/semver/functions/inc.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/inc.js
 var require_inc = __commonJS({
-  "node_modules/semver/functions/inc.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/inc.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var inc = (version, release, options, identifier, identifierBase) => {
@@ -6710,9 +6741,9 @@ var require_inc = __commonJS({
   }
 });
 
-// node_modules/semver/functions/diff.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/diff.js
 var require_diff = __commonJS({
-  "node_modules/semver/functions/diff.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/diff.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var diff = (version1, version2) => {
@@ -6754,9 +6785,9 @@ var require_diff = __commonJS({
   }
 });
 
-// node_modules/semver/functions/major.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/major.js
 var require_major = __commonJS({
-  "node_modules/semver/functions/major.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/major.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var major = (a, loose) => new SemVer(a, loose).major;
@@ -6764,9 +6795,9 @@ var require_major = __commonJS({
   }
 });
 
-// node_modules/semver/functions/minor.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/minor.js
 var require_minor = __commonJS({
-  "node_modules/semver/functions/minor.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/minor.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var minor = (a, loose) => new SemVer(a, loose).minor;
@@ -6774,9 +6805,9 @@ var require_minor = __commonJS({
   }
 });
 
-// node_modules/semver/functions/patch.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/patch.js
 var require_patch = __commonJS({
-  "node_modules/semver/functions/patch.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/patch.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var patch = (a, loose) => new SemVer(a, loose).patch;
@@ -6784,9 +6815,9 @@ var require_patch = __commonJS({
   }
 });
 
-// node_modules/semver/functions/prerelease.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/prerelease.js
 var require_prerelease = __commonJS({
-  "node_modules/semver/functions/prerelease.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/prerelease.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var prerelease = (version, options) => {
@@ -6797,9 +6828,9 @@ var require_prerelease = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js
 var require_compare = __commonJS({
-  "node_modules/semver/functions/compare.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var compare = (a, b, loose) => new SemVer(a, loose).compare(new SemVer(b, loose));
@@ -6807,9 +6838,9 @@ var require_compare = __commonJS({
   }
 });
 
-// node_modules/semver/functions/rcompare.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rcompare.js
 var require_rcompare = __commonJS({
-  "node_modules/semver/functions/rcompare.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rcompare.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var rcompare = (a, b, loose) => compare(b, a, loose);
@@ -6817,9 +6848,9 @@ var require_rcompare = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare-loose.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-loose.js
 var require_compare_loose = __commonJS({
-  "node_modules/semver/functions/compare-loose.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-loose.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var compareLoose = (a, b) => compare(a, b, true);
@@ -6827,9 +6858,9 @@ var require_compare_loose = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare-build.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-build.js
 var require_compare_build = __commonJS({
-  "node_modules/semver/functions/compare-build.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-build.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var compareBuild = (a, b, loose) => {
@@ -6841,9 +6872,9 @@ var require_compare_build = __commonJS({
   }
 });
 
-// node_modules/semver/functions/sort.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/sort.js
 var require_sort = __commonJS({
-  "node_modules/semver/functions/sort.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/sort.js"(exports2, module2) {
     "use strict";
     var compareBuild = require_compare_build();
     var sort = (list, loose) => list.sort((a, b) => compareBuild(a, b, loose));
@@ -6851,9 +6882,9 @@ var require_sort = __commonJS({
   }
 });
 
-// node_modules/semver/functions/rsort.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rsort.js
 var require_rsort = __commonJS({
-  "node_modules/semver/functions/rsort.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rsort.js"(exports2, module2) {
     "use strict";
     var compareBuild = require_compare_build();
     var rsort = (list, loose) => list.sort((a, b) => compareBuild(b, a, loose));
@@ -6861,9 +6892,9 @@ var require_rsort = __commonJS({
   }
 });
 
-// node_modules/semver/functions/gt.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gt.js
 var require_gt = __commonJS({
-  "node_modules/semver/functions/gt.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gt.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var gt = (a, b, loose) => compare(a, b, loose) > 0;
@@ -6871,9 +6902,9 @@ var require_gt = __commonJS({
   }
 });
 
-// node_modules/semver/functions/lt.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lt.js
 var require_lt = __commonJS({
-  "node_modules/semver/functions/lt.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lt.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var lt = (a, b, loose) => compare(a, b, loose) < 0;
@@ -6881,9 +6912,9 @@ var require_lt = __commonJS({
   }
 });
 
-// node_modules/semver/functions/eq.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/eq.js
 var require_eq = __commonJS({
-  "node_modules/semver/functions/eq.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/eq.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var eq = (a, b, loose) => compare(a, b, loose) === 0;
@@ -6891,9 +6922,9 @@ var require_eq = __commonJS({
   }
 });
 
-// node_modules/semver/functions/neq.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/neq.js
 var require_neq = __commonJS({
-  "node_modules/semver/functions/neq.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/neq.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var neq = (a, b, loose) => compare(a, b, loose) !== 0;
@@ -6901,9 +6932,9 @@ var require_neq = __commonJS({
   }
 });
 
-// node_modules/semver/functions/gte.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gte.js
 var require_gte = __commonJS({
-  "node_modules/semver/functions/gte.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gte.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var gte = (a, b, loose) => compare(a, b, loose) >= 0;
@@ -6911,9 +6942,9 @@ var require_gte = __commonJS({
   }
 });
 
-// node_modules/semver/functions/lte.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lte.js
 var require_lte = __commonJS({
-  "node_modules/semver/functions/lte.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lte.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var lte = (a, b, loose) => compare(a, b, loose) <= 0;
@@ -6921,9 +6952,9 @@ var require_lte = __commonJS({
   }
 });
 
-// node_modules/semver/functions/cmp.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/cmp.js
 var require_cmp = __commonJS({
-  "node_modules/semver/functions/cmp.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/cmp.js"(exports2, module2) {
     "use strict";
     var eq = require_eq();
     var neq = require_neq();
@@ -6971,9 +7002,9 @@ var require_cmp = __commonJS({
   }
 });
 
-// node_modules/semver/functions/coerce.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/coerce.js
 var require_coerce = __commonJS({
-  "node_modules/semver/functions/coerce.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/coerce.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var parse = require_parse();
@@ -7017,9 +7048,9 @@ var require_coerce = __commonJS({
   }
 });
 
-// node_modules/semver/internal/lrucache.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/lrucache.js
 var require_lrucache = __commonJS({
-  "node_modules/semver/internal/lrucache.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/lrucache.js"(exports2, module2) {
     "use strict";
     var LRUCache = class {
       constructor() {
@@ -7055,9 +7086,9 @@ var require_lrucache = __commonJS({
   }
 });
 
-// node_modules/semver/classes/range.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/range.js
 var require_range = __commonJS({
-  "node_modules/semver/classes/range.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/range.js"(exports2, module2) {
     "use strict";
     var SPACE_CHARACTERS = /\s+/g;
     var Range = class _Range {
@@ -7228,6 +7259,7 @@ var require_range = __commonJS({
       return result;
     };
     var parseComparator = (comp, options) => {
+      comp = comp.replace(re[t.BUILD], "");
       debug("comp", comp, options);
       comp = replaceCarets(comp, options);
       debug("caret", comp);
@@ -7431,9 +7463,9 @@ var require_range = __commonJS({
   }
 });
 
-// node_modules/semver/classes/comparator.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/comparator.js
 var require_comparator = __commonJS({
-  "node_modules/semver/classes/comparator.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/comparator.js"(exports2, module2) {
     "use strict";
     var ANY = Symbol("SemVer ANY");
     var Comparator = class _Comparator {
@@ -7544,9 +7576,9 @@ var require_comparator = __commonJS({
   }
 });
 
-// node_modules/semver/functions/satisfies.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/satisfies.js
 var require_satisfies = __commonJS({
-  "node_modules/semver/functions/satisfies.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/satisfies.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var satisfies = (version, range, options) => {
@@ -7561,9 +7593,9 @@ var require_satisfies = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/to-comparators.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/to-comparators.js
 var require_to_comparators = __commonJS({
-  "node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var toComparators = (range, options) => new Range(range, options).set.map((comp) => comp.map((c) => c.value).join(" ").trim().split(" "));
@@ -7571,9 +7603,9 @@ var require_to_comparators = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/max-satisfying.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/max-satisfying.js
 var require_max_satisfying = __commonJS({
-  "node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7600,9 +7632,9 @@ var require_max_satisfying = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/min-satisfying.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-satisfying.js
 var require_min_satisfying = __commonJS({
-  "node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7629,9 +7661,9 @@ var require_min_satisfying = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/min-version.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-version.js
 var require_min_version = __commonJS({
-  "node_modules/semver/ranges/min-version.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-version.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7688,9 +7720,9 @@ var require_min_version = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/valid.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/valid.js
 var require_valid2 = __commonJS({
-  "node_modules/semver/ranges/valid.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/valid.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var validRange = (range, options) => {
@@ -7704,9 +7736,9 @@ var require_valid2 = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/outside.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/outside.js
 var require_outside = __commonJS({
-  "node_modules/semver/ranges/outside.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/outside.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Comparator = require_comparator();
@@ -7773,9 +7805,9 @@ var require_outside = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/gtr.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/gtr.js
 var require_gtr = __commonJS({
-  "node_modules/semver/ranges/gtr.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/gtr.js"(exports2, module2) {
     "use strict";
     var outside = require_outside();
     var gtr = (version, range, options) => outside(version, range, ">", options);
@@ -7783,9 +7815,9 @@ var require_gtr = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/ltr.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/ltr.js
 var require_ltr = __commonJS({
-  "node_modules/semver/ranges/ltr.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/ltr.js"(exports2, module2) {
     "use strict";
     var outside = require_outside();
     var ltr = (version, range, options) => outside(version, range, "<", options);
@@ -7793,9 +7825,9 @@ var require_ltr = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/intersects.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/intersects.js
 var require_intersects = __commonJS({
-  "node_modules/semver/ranges/intersects.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/intersects.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var intersects = (r1, r2, options) => {
@@ -7807,9 +7839,9 @@ var require_intersects = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/simplify.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/simplify.js
 var require_simplify = __commonJS({
-  "node_modules/semver/ranges/simplify.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/simplify.js"(exports2, module2) {
     "use strict";
     var satisfies = require_satisfies();
     var compare = require_compare();
@@ -7857,9 +7889,9 @@ var require_simplify = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/subset.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/subset.js
 var require_subset = __commonJS({
-  "node_modules/semver/ranges/subset.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/subset.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var Comparator = require_comparator();
@@ -8019,9 +8051,9 @@ var require_subset = __commonJS({
   }
 });
 
-// node_modules/semver/index.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/index.js
 var require_semver2 = __commonJS({
-  "node_modules/semver/index.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/index.js"(exports2, module2) {
     "use strict";
     var internalRe = require_re();
     var constants = require_constants();
@@ -8114,25 +8146,25 @@ var require_semver2 = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js
 var require_asymmetricKeyDetailsSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, ">=15.7.0");
   }
 });
 
-// node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js
 var require_rsaPssKeyDetailsSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, ">=16.9.0");
   }
 });
 
-// node_modules/jsonwebtoken/lib/validateAsymmetricKey.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/validateAsymmetricKey.js
 var require_validateAsymmetricKey = __commonJS({
-  "node_modules/jsonwebtoken/lib/validateAsymmetricKey.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/validateAsymmetricKey.js"(exports2, module2) {
     var ASYMMETRIC_KEY_DETAILS_SUPPORTED = require_asymmetricKeyDetailsSupported();
     var RSA_PSS_KEY_DETAILS_SUPPORTED = require_rsaPssKeyDetailsSupported();
     var allowedAlgorithmsForKeys = {
@@ -8183,17 +8215,17 @@ var require_validateAsymmetricKey = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/psSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/psSupported.js
 var require_psSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/psSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/psSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, "^6.12.0 || >=8.0.0");
   }
 });
 
-// node_modules/jsonwebtoken/verify.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/verify.js
 var require_verify = __commonJS({
-  "node_modules/jsonwebtoken/verify.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/verify.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var NotBeforeError = require_NotBeforeError();
     var TokenExpiredError = require_TokenExpiredError();
@@ -8406,9 +8438,9 @@ var require_verify = __commonJS({
   }
 });
 
-// node_modules/lodash.includes/index.js
+// node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes/index.js
 var require_lodash = __commonJS({
-  "node_modules/lodash.includes/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes/index.js"(exports2, module2) {
     var INFINITY = 1 / 0;
     var MAX_SAFE_INTEGER = 9007199254740991;
     var MAX_INTEGER = 17976931348623157e292;
@@ -8590,9 +8622,9 @@ var require_lodash = __commonJS({
   }
 });
 
-// node_modules/lodash.isboolean/index.js
+// node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean/index.js
 var require_lodash2 = __commonJS({
-  "node_modules/lodash.isboolean/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean/index.js"(exports2, module2) {
     var boolTag = "[object Boolean]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8606,9 +8638,9 @@ var require_lodash2 = __commonJS({
   }
 });
 
-// node_modules/lodash.isinteger/index.js
+// node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger/index.js
 var require_lodash3 = __commonJS({
-  "node_modules/lodash.isinteger/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger/index.js"(exports2, module2) {
     var INFINITY = 1 / 0;
     var MAX_INTEGER = 17976931348623157e292;
     var NAN = 0 / 0;
@@ -8670,9 +8702,9 @@ var require_lodash3 = __commonJS({
   }
 });
 
-// node_modules/lodash.isnumber/index.js
+// node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber/index.js
 var require_lodash4 = __commonJS({
-  "node_modules/lodash.isnumber/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber/index.js"(exports2, module2) {
     var numberTag = "[object Number]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8686,9 +8718,9 @@ var require_lodash4 = __commonJS({
   }
 });
 
-// node_modules/lodash.isplainobject/index.js
+// node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject/index.js
 var require_lodash5 = __commonJS({
-  "node_modules/lodash.isplainobject/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject/index.js"(exports2, module2) {
     var objectTag = "[object Object]";
     function isHostObject(value) {
       var result = false;
@@ -8730,9 +8762,9 @@ var require_lodash5 = __commonJS({
   }
 });
 
-// node_modules/lodash.isstring/index.js
+// node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring/index.js
 var require_lodash6 = __commonJS({
-  "node_modules/lodash.isstring/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring/index.js"(exports2, module2) {
     var stringTag = "[object String]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8747,9 +8779,9 @@ var require_lodash6 = __commonJS({
   }
 });
 
-// node_modules/lodash.once/index.js
+// node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once/index.js
 var require_lodash7 = __commonJS({
-  "node_modules/lodash.once/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once/index.js"(exports2, module2) {
     var FUNC_ERROR_TEXT = "Expected a function";
     var INFINITY = 1 / 0;
     var MAX_INTEGER = 17976931348623157e292;
@@ -8828,9 +8860,9 @@ var require_lodash7 = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/sign.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/sign.js
 var require_sign = __commonJS({
-  "node_modules/jsonwebtoken/sign.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/sign.js"(exports2, module2) {
     var timespan = require_timespan();
     var PS_SUPPORTED = require_psSupported();
     var validateAsymmetricKey = require_validateAsymmetricKey();
@@ -9053,9 +9085,9 @@ var require_sign = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/index.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/index.js
 var require_jsonwebtoken = __commonJS({
-  "node_modules/jsonwebtoken/index.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/index.js"(exports2, module2) {
     module2.exports = {
       decode: require_decode(),
       verify: require_verify(),
@@ -9067,7 +9099,7 @@ var require_jsonwebtoken = __commonJS({
   }
 });
 
-// node_modules/nano-spawn/source/context.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/context.js
 var import_node_process = __toESM(require("node:process"), 1);
 var import_node_util = require("node:util");
 var getContext = (raw) => ({
@@ -9077,7 +9109,7 @@ var getContext = (raw) => ({
 });
 var getCommandPart = (part) => /[^\w./-]/.test(part) ? `'${part.replaceAll("'", "'\\''")}'` : part;
 
-// node_modules/nano-spawn/source/options.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/options.js
 var import_node_path = __toESM(require("node:path"), 1);
 var import_node_url = require("node:url");
 var import_node_process2 = __toESM(require("node:process"), 1);
@@ -9109,12 +9141,12 @@ var addLocalPath = ({ Path = "", PATH = Path, ...env }, cwd) => {
 };
 var getLocalPaths = (localPaths, localPath) => localPaths.at(-1) === localPath ? localPaths : getLocalPaths([...localPaths, localPath], import_node_path.default.resolve(localPath, ".."));
 
-// node_modules/nano-spawn/source/spawn.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/spawn.js
 var import_node_child_process = require("node:child_process");
 var import_node_events2 = require("node:events");
 var import_node_process5 = __toESM(require("node:process"), 1);
 
-// node_modules/nano-spawn/source/windows.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/windows.js
 var import_promises = __toESM(require("node:fs/promises"), 1);
 var import_node_path2 = __toESM(require("node:path"), 1);
 var import_node_process3 = __toESM(require("node:process"), 1);
@@ -9148,7 +9180,7 @@ var exeExtensions = [".exe", ".com"];
 var escapeArgument = (argument) => escapeFile(escapeFile(`"${argument.replaceAll(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1")}"`));
 var escapeFile = (file) => file.replaceAll(/([()\][%!^"`<>&|;, *?])/g, "^$1");
 
-// node_modules/nano-spawn/source/result.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/result.js
 var import_node_events = require("node:events");
 var import_node_process4 = __toESM(require("node:process"), 1);
 var getResult = async (nodeChildProcess, { input }, context) => {
@@ -9207,7 +9239,7 @@ var getOutputs = ({ state: { stdout, stderr, output }, command, start }) => ({
 });
 var getOutput = (output) => output.at(-1) === "\n" ? output.slice(0, output.at(-2) === "\r" ? -2 : -1) : output;
 
-// node_modules/nano-spawn/source/spawn.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/spawn.js
 var spawnSubprocess = async (file, commandArguments, options, context) => {
   try {
     if (["node", "node.exe"].includes(file.toLowerCase())) {
@@ -9241,7 +9273,7 @@ var bufferOutput = (stream, { state }, streamName) => {
   }
 };
 
-// node_modules/nano-spawn/source/pipe.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/pipe.js
 var import_promises2 = require("node:stream/promises");
 var handlePipe = async (subprocesses) => {
   const [[from, to]] = await Promise.all([Promise.allSettled(subprocesses), pipeStreams(subprocesses)]);
@@ -9275,7 +9307,7 @@ var closeStdin = async (nodeChildProcess) => {
   stdin.end();
 };
 
-// node_modules/nano-spawn/source/iterable.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/iterable.js
 var readline = __toESM(require("node:readline/promises"), 1);
 var lineIterator = async function* (subprocess, { state }, streamName) {
   if (state.isIterating === false) {
@@ -9325,7 +9357,7 @@ var getNext = async (iterator) => {
   }
 };
 
-// node_modules/nano-spawn/source/index.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/index.js
 function spawn2(file, second, third, previous) {
   const [commandArguments = [], options = {}] = Array.isArray(second) ? [second, third] : [[], second];
   const context = getContext([file, ...commandArguments]);
@@ -9345,10 +9377,10 @@ function spawn2(file, second, third, previous) {
   });
 }
 
-// node_modules/@stainless-api/github-internal/lib/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/lib/secrets.mjs
 var import_libsodium_wrappers = __toESM(require_libsodium_wrappers(), 1);
 
-// node_modules/@stainless-api/github-internal/lib/auth.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/lib/auth.mjs
 var import_jsonwebtoken = __toESM(require_jsonwebtoken(), 1);
 
 // src/compat/platform.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -30,9 +30,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
 ));
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
-// node_modules/libsodium/dist/modules/libsodium.js
+// node_modules/.pnpm/libsodium@0.7.15/node_modules/libsodium/dist/modules/libsodium.js
 var require_libsodium = __commonJS({
-  "node_modules/libsodium/dist/modules/libsodium.js"(exports2, module2) {
+  "node_modules/.pnpm/libsodium@0.7.15/node_modules/libsodium/dist/modules/libsodium.js"(exports2, module2) {
     !(function(A) {
       function I(A2) {
         "use strict";
@@ -2636,9 +2636,9 @@ var require_libsodium = __commonJS({
   }
 });
 
-// node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js
+// node_modules/.pnpm/libsodium-wrappers@0.7.15/node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js
 var require_libsodium_wrappers = __commonJS({
-  "node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js"(exports2) {
+  "node_modules/.pnpm/libsodium-wrappers@0.7.15/node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js"(exports2) {
     !(function(e) {
       function a(e2, a2) {
         "use strict";
@@ -5239,9 +5239,9 @@ var require_libsodium_wrappers = __commonJS({
   }
 });
 
-// node_modules/safe-buffer/index.js
+// node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer/index.js
 var require_safe_buffer = __commonJS({
-  "node_modules/safe-buffer/index.js"(exports2, module2) {
+  "node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer/index.js"(exports2, module2) {
     var buffer = require("buffer");
     var Buffer2 = buffer.Buffer;
     function copyProps(src, dst) {
@@ -5297,9 +5297,9 @@ var require_safe_buffer = __commonJS({
   }
 });
 
-// node_modules/jws/lib/data-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/data-stream.js
 var require_data_stream = __commonJS({
-  "node_modules/jws/lib/data-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/data-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var Stream = require("stream");
     var util = require("util");
@@ -5345,9 +5345,9 @@ var require_data_stream = __commonJS({
   }
 });
 
-// node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js
+// node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js
 var require_param_bytes_for_alg = __commonJS({
-  "node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js"(exports2, module2) {
+  "node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js"(exports2, module2) {
     "use strict";
     function getParamSize(keySize) {
       var result = (keySize / 8 | 0) + (keySize % 8 === 0 ? 0 : 1);
@@ -5369,9 +5369,9 @@ var require_param_bytes_for_alg = __commonJS({
   }
 });
 
-// node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js
+// node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js
 var require_ecdsa_sig_formatter = __commonJS({
-  "node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js"(exports2, module2) {
+  "node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js"(exports2, module2) {
     "use strict";
     var Buffer2 = require_safe_buffer().Buffer;
     var getParamBytesForAlg = require_param_bytes_for_alg();
@@ -5509,9 +5509,9 @@ var require_ecdsa_sig_formatter = __commonJS({
   }
 });
 
-// node_modules/buffer-equal-constant-time/index.js
+// node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time/index.js
 var require_buffer_equal_constant_time = __commonJS({
-  "node_modules/buffer-equal-constant-time/index.js"(exports2, module2) {
+  "node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time/index.js"(exports2, module2) {
     "use strict";
     var Buffer2 = require("buffer").Buffer;
     var SlowBuffer = require("buffer").SlowBuffer;
@@ -5543,9 +5543,9 @@ var require_buffer_equal_constant_time = __commonJS({
   }
 });
 
-// node_modules/jwa/index.js
+// node_modules/.pnpm/jwa@2.0.1/node_modules/jwa/index.js
 var require_jwa = __commonJS({
-  "node_modules/jwa/index.js"(exports2, module2) {
+  "node_modules/.pnpm/jwa@2.0.1/node_modules/jwa/index.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var crypto = require("crypto");
     var formatEcdsa = require_ecdsa_sig_formatter();
@@ -5754,7 +5754,7 @@ var require_jwa = __commonJS({
         es: createECDSAVerifer,
         none: createNoneVerifier
       };
-      var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/i);
+      var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/);
       if (!match)
         throw typeError(MSG_INVALID_ALGORITHM, algorithm);
       var algo = (match[1] || match[3]).toLowerCase();
@@ -5767,9 +5767,9 @@ var require_jwa = __commonJS({
   }
 });
 
-// node_modules/jws/lib/tostring.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/tostring.js
 var require_tostring = __commonJS({
-  "node_modules/jws/lib/tostring.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/tostring.js"(exports2, module2) {
     var Buffer2 = require("buffer").Buffer;
     module2.exports = function toString(obj) {
       if (typeof obj === "string")
@@ -5781,9 +5781,9 @@ var require_tostring = __commonJS({
   }
 });
 
-// node_modules/jws/lib/sign-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/sign-stream.js
 var require_sign_stream = __commonJS({
-  "node_modules/jws/lib/sign-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/sign-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var DataStream = require_data_stream();
     var jwa = require_jwa();
@@ -5810,7 +5810,12 @@ var require_sign_stream = __commonJS({
       return util.format("%s.%s", securedInput, signature);
     }
     function SignStream(opts) {
-      var secret = opts.secret || opts.privateKey || opts.key;
+      var secret = opts.secret;
+      secret = secret == null ? opts.privateKey : secret;
+      secret = secret == null ? opts.key : secret;
+      if (/^hs/i.test(opts.header.alg) === true && secret == null) {
+        throw new TypeError("secret must be a string or buffer or a KeyObject");
+      }
       var secretStream = new DataStream(secret);
       this.readable = true;
       this.header = opts.header;
@@ -5851,9 +5856,9 @@ var require_sign_stream = __commonJS({
   }
 });
 
-// node_modules/jws/lib/verify-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/verify-stream.js
 var require_verify_stream = __commonJS({
-  "node_modules/jws/lib/verify-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/verify-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var DataStream = require_data_stream();
     var jwa = require_jwa();
@@ -5922,7 +5927,12 @@ var require_verify_stream = __commonJS({
     }
     function VerifyStream(opts) {
       opts = opts || {};
-      var secretOrKey = opts.secret || opts.publicKey || opts.key;
+      var secretOrKey = opts.secret;
+      secretOrKey = secretOrKey == null ? opts.publicKey : secretOrKey;
+      secretOrKey = secretOrKey == null ? opts.key : secretOrKey;
+      if (/^hs/i.test(opts.algorithm) === true && secretOrKey == null) {
+        throw new TypeError("secret must be a string or buffer or a KeyObject");
+      }
       var secretStream = new DataStream(secretOrKey);
       this.readable = true;
       this.algorithm = opts.algorithm;
@@ -5961,9 +5971,9 @@ var require_verify_stream = __commonJS({
   }
 });
 
-// node_modules/jws/index.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/index.js
 var require_jws = __commonJS({
-  "node_modules/jws/index.js"(exports2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/index.js"(exports2) {
     var SignStream = require_sign_stream();
     var VerifyStream = require_verify_stream();
     var ALGORITHMS = [
@@ -5994,9 +6004,9 @@ var require_jws = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/decode.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/decode.js
 var require_decode = __commonJS({
-  "node_modules/jsonwebtoken/decode.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/decode.js"(exports2, module2) {
     var jws = require_jws();
     module2.exports = function(jwt, options) {
       options = options || {};
@@ -6026,9 +6036,9 @@ var require_decode = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/JsonWebTokenError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/JsonWebTokenError.js
 var require_JsonWebTokenError = __commonJS({
-  "node_modules/jsonwebtoken/lib/JsonWebTokenError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/JsonWebTokenError.js"(exports2, module2) {
     var JsonWebTokenError = function(message, error) {
       Error.call(this, message);
       if (Error.captureStackTrace) {
@@ -6044,9 +6054,9 @@ var require_JsonWebTokenError = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/NotBeforeError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/NotBeforeError.js
 var require_NotBeforeError = __commonJS({
-  "node_modules/jsonwebtoken/lib/NotBeforeError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/NotBeforeError.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var NotBeforeError = function(message, date) {
       JsonWebTokenError.call(this, message);
@@ -6059,9 +6069,9 @@ var require_NotBeforeError = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/TokenExpiredError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/TokenExpiredError.js
 var require_TokenExpiredError = __commonJS({
-  "node_modules/jsonwebtoken/lib/TokenExpiredError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/TokenExpiredError.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var TokenExpiredError = function(message, expiredAt) {
       JsonWebTokenError.call(this, message);
@@ -6074,9 +6084,9 @@ var require_TokenExpiredError = __commonJS({
   }
 });
 
-// node_modules/ms/index.js
+// node_modules/.pnpm/ms@2.1.3/node_modules/ms/index.js
 var require_ms = __commonJS({
-  "node_modules/ms/index.js"(exports2, module2) {
+  "node_modules/.pnpm/ms@2.1.3/node_modules/ms/index.js"(exports2, module2) {
     var s = 1e3;
     var m = s * 60;
     var h = m * 60;
@@ -6190,9 +6200,9 @@ var require_ms = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/timespan.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/timespan.js
 var require_timespan = __commonJS({
-  "node_modules/jsonwebtoken/lib/timespan.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/timespan.js"(exports2, module2) {
     var ms = require_ms();
     module2.exports = function(time, iat) {
       var timestamp = iat || Math.floor(Date.now() / 1e3);
@@ -6211,9 +6221,9 @@ var require_timespan = __commonJS({
   }
 });
 
-// node_modules/semver/internal/constants.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/constants.js
 var require_constants = __commonJS({
-  "node_modules/semver/internal/constants.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/constants.js"(exports2, module2) {
     "use strict";
     var SEMVER_SPEC_VERSION = "2.0.0";
     var MAX_LENGTH = 256;
@@ -6243,9 +6253,9 @@ var require_constants = __commonJS({
   }
 });
 
-// node_modules/semver/internal/debug.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/debug.js
 var require_debug = __commonJS({
-  "node_modules/semver/internal/debug.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/debug.js"(exports2, module2) {
     "use strict";
     var debug = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
     };
@@ -6253,9 +6263,9 @@ var require_debug = __commonJS({
   }
 });
 
-// node_modules/semver/internal/re.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/re.js
 var require_re = __commonJS({
-  "node_modules/semver/internal/re.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/re.js"(exports2, module2) {
     "use strict";
     var {
       MAX_SAFE_COMPONENT_LENGTH,
@@ -6341,9 +6351,9 @@ var require_re = __commonJS({
   }
 });
 
-// node_modules/semver/internal/parse-options.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/parse-options.js
 var require_parse_options = __commonJS({
-  "node_modules/semver/internal/parse-options.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/parse-options.js"(exports2, module2) {
     "use strict";
     var looseOption = Object.freeze({ loose: true });
     var emptyOpts = Object.freeze({});
@@ -6360,12 +6370,15 @@ var require_parse_options = __commonJS({
   }
 });
 
-// node_modules/semver/internal/identifiers.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/identifiers.js
 var require_identifiers = __commonJS({
-  "node_modules/semver/internal/identifiers.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/identifiers.js"(exports2, module2) {
     "use strict";
     var numeric = /^[0-9]+$/;
     var compareIdentifiers = (a, b) => {
+      if (typeof a === "number" && typeof b === "number") {
+        return a === b ? 0 : a < b ? -1 : 1;
+      }
       const anum = numeric.test(a);
       const bnum = numeric.test(b);
       if (anum && bnum) {
@@ -6382,9 +6395,9 @@ var require_identifiers = __commonJS({
   }
 });
 
-// node_modules/semver/classes/semver.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js
 var require_semver = __commonJS({
-  "node_modules/semver/classes/semver.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js"(exports2, module2) {
     "use strict";
     var debug = require_debug();
     var { MAX_LENGTH, MAX_SAFE_INTEGER } = require_constants();
@@ -6472,7 +6485,25 @@ var require_semver = __commonJS({
         if (!(other instanceof _SemVer)) {
           other = new _SemVer(other, this.options);
         }
-        return compareIdentifiers(this.major, other.major) || compareIdentifiers(this.minor, other.minor) || compareIdentifiers(this.patch, other.patch);
+        if (this.major < other.major) {
+          return -1;
+        }
+        if (this.major > other.major) {
+          return 1;
+        }
+        if (this.minor < other.minor) {
+          return -1;
+        }
+        if (this.minor > other.minor) {
+          return 1;
+        }
+        if (this.patch < other.patch) {
+          return -1;
+        }
+        if (this.patch > other.patch) {
+          return 1;
+        }
+        return 0;
       }
       comparePre(other) {
         if (!(other instanceof _SemVer)) {
@@ -6643,9 +6674,9 @@ var require_semver = __commonJS({
   }
 });
 
-// node_modules/semver/functions/parse.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/parse.js
 var require_parse = __commonJS({
-  "node_modules/semver/functions/parse.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/parse.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var parse = (version, options, throwErrors = false) => {
@@ -6665,9 +6696,9 @@ var require_parse = __commonJS({
   }
 });
 
-// node_modules/semver/functions/valid.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/valid.js
 var require_valid = __commonJS({
-  "node_modules/semver/functions/valid.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/valid.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var valid = (version, options) => {
@@ -6678,9 +6709,9 @@ var require_valid = __commonJS({
   }
 });
 
-// node_modules/semver/functions/clean.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/clean.js
 var require_clean = __commonJS({
-  "node_modules/semver/functions/clean.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/clean.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var clean = (version, options) => {
@@ -6691,9 +6722,9 @@ var require_clean = __commonJS({
   }
 });
 
-// node_modules/semver/functions/inc.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/inc.js
 var require_inc = __commonJS({
-  "node_modules/semver/functions/inc.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/inc.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var inc = (version, release, options, identifier, identifierBase) => {
@@ -6715,9 +6746,9 @@ var require_inc = __commonJS({
   }
 });
 
-// node_modules/semver/functions/diff.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/diff.js
 var require_diff = __commonJS({
-  "node_modules/semver/functions/diff.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/diff.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var diff = (version1, version2) => {
@@ -6759,9 +6790,9 @@ var require_diff = __commonJS({
   }
 });
 
-// node_modules/semver/functions/major.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/major.js
 var require_major = __commonJS({
-  "node_modules/semver/functions/major.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/major.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var major = (a, loose) => new SemVer(a, loose).major;
@@ -6769,9 +6800,9 @@ var require_major = __commonJS({
   }
 });
 
-// node_modules/semver/functions/minor.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/minor.js
 var require_minor = __commonJS({
-  "node_modules/semver/functions/minor.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/minor.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var minor = (a, loose) => new SemVer(a, loose).minor;
@@ -6779,9 +6810,9 @@ var require_minor = __commonJS({
   }
 });
 
-// node_modules/semver/functions/patch.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/patch.js
 var require_patch = __commonJS({
-  "node_modules/semver/functions/patch.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/patch.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var patch = (a, loose) => new SemVer(a, loose).patch;
@@ -6789,9 +6820,9 @@ var require_patch = __commonJS({
   }
 });
 
-// node_modules/semver/functions/prerelease.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/prerelease.js
 var require_prerelease = __commonJS({
-  "node_modules/semver/functions/prerelease.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/prerelease.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var prerelease = (version, options) => {
@@ -6802,9 +6833,9 @@ var require_prerelease = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js
 var require_compare = __commonJS({
-  "node_modules/semver/functions/compare.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var compare = (a, b, loose) => new SemVer(a, loose).compare(new SemVer(b, loose));
@@ -6812,9 +6843,9 @@ var require_compare = __commonJS({
   }
 });
 
-// node_modules/semver/functions/rcompare.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rcompare.js
 var require_rcompare = __commonJS({
-  "node_modules/semver/functions/rcompare.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rcompare.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var rcompare = (a, b, loose) => compare(b, a, loose);
@@ -6822,9 +6853,9 @@ var require_rcompare = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare-loose.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-loose.js
 var require_compare_loose = __commonJS({
-  "node_modules/semver/functions/compare-loose.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-loose.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var compareLoose = (a, b) => compare(a, b, true);
@@ -6832,9 +6863,9 @@ var require_compare_loose = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare-build.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-build.js
 var require_compare_build = __commonJS({
-  "node_modules/semver/functions/compare-build.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-build.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var compareBuild = (a, b, loose) => {
@@ -6846,9 +6877,9 @@ var require_compare_build = __commonJS({
   }
 });
 
-// node_modules/semver/functions/sort.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/sort.js
 var require_sort = __commonJS({
-  "node_modules/semver/functions/sort.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/sort.js"(exports2, module2) {
     "use strict";
     var compareBuild = require_compare_build();
     var sort = (list, loose) => list.sort((a, b) => compareBuild(a, b, loose));
@@ -6856,9 +6887,9 @@ var require_sort = __commonJS({
   }
 });
 
-// node_modules/semver/functions/rsort.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rsort.js
 var require_rsort = __commonJS({
-  "node_modules/semver/functions/rsort.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rsort.js"(exports2, module2) {
     "use strict";
     var compareBuild = require_compare_build();
     var rsort = (list, loose) => list.sort((a, b) => compareBuild(b, a, loose));
@@ -6866,9 +6897,9 @@ var require_rsort = __commonJS({
   }
 });
 
-// node_modules/semver/functions/gt.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gt.js
 var require_gt = __commonJS({
-  "node_modules/semver/functions/gt.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gt.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var gt = (a, b, loose) => compare(a, b, loose) > 0;
@@ -6876,9 +6907,9 @@ var require_gt = __commonJS({
   }
 });
 
-// node_modules/semver/functions/lt.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lt.js
 var require_lt = __commonJS({
-  "node_modules/semver/functions/lt.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lt.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var lt = (a, b, loose) => compare(a, b, loose) < 0;
@@ -6886,9 +6917,9 @@ var require_lt = __commonJS({
   }
 });
 
-// node_modules/semver/functions/eq.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/eq.js
 var require_eq = __commonJS({
-  "node_modules/semver/functions/eq.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/eq.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var eq = (a, b, loose) => compare(a, b, loose) === 0;
@@ -6896,9 +6927,9 @@ var require_eq = __commonJS({
   }
 });
 
-// node_modules/semver/functions/neq.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/neq.js
 var require_neq = __commonJS({
-  "node_modules/semver/functions/neq.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/neq.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var neq = (a, b, loose) => compare(a, b, loose) !== 0;
@@ -6906,9 +6937,9 @@ var require_neq = __commonJS({
   }
 });
 
-// node_modules/semver/functions/gte.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gte.js
 var require_gte = __commonJS({
-  "node_modules/semver/functions/gte.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gte.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var gte = (a, b, loose) => compare(a, b, loose) >= 0;
@@ -6916,9 +6947,9 @@ var require_gte = __commonJS({
   }
 });
 
-// node_modules/semver/functions/lte.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lte.js
 var require_lte = __commonJS({
-  "node_modules/semver/functions/lte.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lte.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var lte = (a, b, loose) => compare(a, b, loose) <= 0;
@@ -6926,9 +6957,9 @@ var require_lte = __commonJS({
   }
 });
 
-// node_modules/semver/functions/cmp.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/cmp.js
 var require_cmp = __commonJS({
-  "node_modules/semver/functions/cmp.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/cmp.js"(exports2, module2) {
     "use strict";
     var eq = require_eq();
     var neq = require_neq();
@@ -6976,9 +7007,9 @@ var require_cmp = __commonJS({
   }
 });
 
-// node_modules/semver/functions/coerce.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/coerce.js
 var require_coerce = __commonJS({
-  "node_modules/semver/functions/coerce.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/coerce.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var parse = require_parse();
@@ -7022,9 +7053,9 @@ var require_coerce = __commonJS({
   }
 });
 
-// node_modules/semver/internal/lrucache.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/lrucache.js
 var require_lrucache = __commonJS({
-  "node_modules/semver/internal/lrucache.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/lrucache.js"(exports2, module2) {
     "use strict";
     var LRUCache = class {
       constructor() {
@@ -7060,9 +7091,9 @@ var require_lrucache = __commonJS({
   }
 });
 
-// node_modules/semver/classes/range.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/range.js
 var require_range = __commonJS({
-  "node_modules/semver/classes/range.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/range.js"(exports2, module2) {
     "use strict";
     var SPACE_CHARACTERS = /\s+/g;
     var Range = class _Range {
@@ -7233,6 +7264,7 @@ var require_range = __commonJS({
       return result;
     };
     var parseComparator = (comp, options) => {
+      comp = comp.replace(re[t.BUILD], "");
       debug("comp", comp, options);
       comp = replaceCarets(comp, options);
       debug("caret", comp);
@@ -7436,9 +7468,9 @@ var require_range = __commonJS({
   }
 });
 
-// node_modules/semver/classes/comparator.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/comparator.js
 var require_comparator = __commonJS({
-  "node_modules/semver/classes/comparator.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/comparator.js"(exports2, module2) {
     "use strict";
     var ANY = Symbol("SemVer ANY");
     var Comparator = class _Comparator {
@@ -7549,9 +7581,9 @@ var require_comparator = __commonJS({
   }
 });
 
-// node_modules/semver/functions/satisfies.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/satisfies.js
 var require_satisfies = __commonJS({
-  "node_modules/semver/functions/satisfies.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/satisfies.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var satisfies = (version, range, options) => {
@@ -7566,9 +7598,9 @@ var require_satisfies = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/to-comparators.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/to-comparators.js
 var require_to_comparators = __commonJS({
-  "node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var toComparators = (range, options) => new Range(range, options).set.map((comp) => comp.map((c) => c.value).join(" ").trim().split(" "));
@@ -7576,9 +7608,9 @@ var require_to_comparators = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/max-satisfying.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/max-satisfying.js
 var require_max_satisfying = __commonJS({
-  "node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7605,9 +7637,9 @@ var require_max_satisfying = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/min-satisfying.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-satisfying.js
 var require_min_satisfying = __commonJS({
-  "node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7634,9 +7666,9 @@ var require_min_satisfying = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/min-version.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-version.js
 var require_min_version = __commonJS({
-  "node_modules/semver/ranges/min-version.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-version.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7693,9 +7725,9 @@ var require_min_version = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/valid.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/valid.js
 var require_valid2 = __commonJS({
-  "node_modules/semver/ranges/valid.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/valid.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var validRange = (range, options) => {
@@ -7709,9 +7741,9 @@ var require_valid2 = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/outside.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/outside.js
 var require_outside = __commonJS({
-  "node_modules/semver/ranges/outside.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/outside.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Comparator = require_comparator();
@@ -7778,9 +7810,9 @@ var require_outside = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/gtr.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/gtr.js
 var require_gtr = __commonJS({
-  "node_modules/semver/ranges/gtr.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/gtr.js"(exports2, module2) {
     "use strict";
     var outside = require_outside();
     var gtr = (version, range, options) => outside(version, range, ">", options);
@@ -7788,9 +7820,9 @@ var require_gtr = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/ltr.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/ltr.js
 var require_ltr = __commonJS({
-  "node_modules/semver/ranges/ltr.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/ltr.js"(exports2, module2) {
     "use strict";
     var outside = require_outside();
     var ltr = (version, range, options) => outside(version, range, "<", options);
@@ -7798,9 +7830,9 @@ var require_ltr = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/intersects.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/intersects.js
 var require_intersects = __commonJS({
-  "node_modules/semver/ranges/intersects.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/intersects.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var intersects = (r1, r2, options) => {
@@ -7812,9 +7844,9 @@ var require_intersects = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/simplify.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/simplify.js
 var require_simplify = __commonJS({
-  "node_modules/semver/ranges/simplify.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/simplify.js"(exports2, module2) {
     "use strict";
     var satisfies = require_satisfies();
     var compare = require_compare();
@@ -7862,9 +7894,9 @@ var require_simplify = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/subset.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/subset.js
 var require_subset = __commonJS({
-  "node_modules/semver/ranges/subset.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/subset.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var Comparator = require_comparator();
@@ -8024,9 +8056,9 @@ var require_subset = __commonJS({
   }
 });
 
-// node_modules/semver/index.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/index.js
 var require_semver2 = __commonJS({
-  "node_modules/semver/index.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/index.js"(exports2, module2) {
     "use strict";
     var internalRe = require_re();
     var constants = require_constants();
@@ -8119,25 +8151,25 @@ var require_semver2 = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js
 var require_asymmetricKeyDetailsSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, ">=15.7.0");
   }
 });
 
-// node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js
 var require_rsaPssKeyDetailsSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, ">=16.9.0");
   }
 });
 
-// node_modules/jsonwebtoken/lib/validateAsymmetricKey.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/validateAsymmetricKey.js
 var require_validateAsymmetricKey = __commonJS({
-  "node_modules/jsonwebtoken/lib/validateAsymmetricKey.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/validateAsymmetricKey.js"(exports2, module2) {
     var ASYMMETRIC_KEY_DETAILS_SUPPORTED = require_asymmetricKeyDetailsSupported();
     var RSA_PSS_KEY_DETAILS_SUPPORTED = require_rsaPssKeyDetailsSupported();
     var allowedAlgorithmsForKeys = {
@@ -8188,17 +8220,17 @@ var require_validateAsymmetricKey = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/psSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/psSupported.js
 var require_psSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/psSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/psSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, "^6.12.0 || >=8.0.0");
   }
 });
 
-// node_modules/jsonwebtoken/verify.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/verify.js
 var require_verify = __commonJS({
-  "node_modules/jsonwebtoken/verify.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/verify.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var NotBeforeError = require_NotBeforeError();
     var TokenExpiredError = require_TokenExpiredError();
@@ -8411,9 +8443,9 @@ var require_verify = __commonJS({
   }
 });
 
-// node_modules/lodash.includes/index.js
+// node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes/index.js
 var require_lodash = __commonJS({
-  "node_modules/lodash.includes/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes/index.js"(exports2, module2) {
     var INFINITY = 1 / 0;
     var MAX_SAFE_INTEGER = 9007199254740991;
     var MAX_INTEGER = 17976931348623157e292;
@@ -8595,9 +8627,9 @@ var require_lodash = __commonJS({
   }
 });
 
-// node_modules/lodash.isboolean/index.js
+// node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean/index.js
 var require_lodash2 = __commonJS({
-  "node_modules/lodash.isboolean/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean/index.js"(exports2, module2) {
     var boolTag = "[object Boolean]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8611,9 +8643,9 @@ var require_lodash2 = __commonJS({
   }
 });
 
-// node_modules/lodash.isinteger/index.js
+// node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger/index.js
 var require_lodash3 = __commonJS({
-  "node_modules/lodash.isinteger/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger/index.js"(exports2, module2) {
     var INFINITY = 1 / 0;
     var MAX_INTEGER = 17976931348623157e292;
     var NAN = 0 / 0;
@@ -8675,9 +8707,9 @@ var require_lodash3 = __commonJS({
   }
 });
 
-// node_modules/lodash.isnumber/index.js
+// node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber/index.js
 var require_lodash4 = __commonJS({
-  "node_modules/lodash.isnumber/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber/index.js"(exports2, module2) {
     var numberTag = "[object Number]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8691,9 +8723,9 @@ var require_lodash4 = __commonJS({
   }
 });
 
-// node_modules/lodash.isplainobject/index.js
+// node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject/index.js
 var require_lodash5 = __commonJS({
-  "node_modules/lodash.isplainobject/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject/index.js"(exports2, module2) {
     var objectTag = "[object Object]";
     function isHostObject(value) {
       var result = false;
@@ -8735,9 +8767,9 @@ var require_lodash5 = __commonJS({
   }
 });
 
-// node_modules/lodash.isstring/index.js
+// node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring/index.js
 var require_lodash6 = __commonJS({
-  "node_modules/lodash.isstring/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring/index.js"(exports2, module2) {
     var stringTag = "[object String]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8752,9 +8784,9 @@ var require_lodash6 = __commonJS({
   }
 });
 
-// node_modules/lodash.once/index.js
+// node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once/index.js
 var require_lodash7 = __commonJS({
-  "node_modules/lodash.once/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once/index.js"(exports2, module2) {
     var FUNC_ERROR_TEXT = "Expected a function";
     var INFINITY = 1 / 0;
     var MAX_INTEGER = 17976931348623157e292;
@@ -8833,9 +8865,9 @@ var require_lodash7 = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/sign.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/sign.js
 var require_sign = __commonJS({
-  "node_modules/jsonwebtoken/sign.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/sign.js"(exports2, module2) {
     var timespan = require_timespan();
     var PS_SUPPORTED = require_psSupported();
     var validateAsymmetricKey = require_validateAsymmetricKey();
@@ -9058,9 +9090,9 @@ var require_sign = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/index.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/index.js
 var require_jsonwebtoken = __commonJS({
-  "node_modules/jsonwebtoken/index.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/index.js"(exports2, module2) {
     module2.exports = {
       decode: require_decode(),
       verify: require_verify(),
@@ -9072,9 +9104,9 @@ var require_jsonwebtoken = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/identity.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/identity.js
 var require_identity = __commonJS({
-  "node_modules/yaml/dist/nodes/identity.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/identity.js"(exports2) {
     "use strict";
     var ALIAS = Symbol.for("yaml.alias");
     var DOC = Symbol.for("yaml.document");
@@ -9129,9 +9161,9 @@ var require_identity = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/visit.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/visit.js
 var require_visit = __commonJS({
-  "node_modules/yaml/dist/visit.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/visit.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var BREAK = Symbol("break visit");
@@ -9287,9 +9319,9 @@ var require_visit = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/directives.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/directives.js
 var require_directives = __commonJS({
-  "node_modules/yaml/dist/doc/directives.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/directives.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -9458,9 +9490,9 @@ var require_directives = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/anchors.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/anchors.js
 var require_anchors = __commonJS({
-  "node_modules/yaml/dist/doc/anchors.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/anchors.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -9528,9 +9560,9 @@ var require_anchors = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/applyReviver.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/applyReviver.js
 var require_applyReviver = __commonJS({
-  "node_modules/yaml/dist/doc/applyReviver.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/applyReviver.js"(exports2) {
     "use strict";
     function applyReviver(reviver, obj, key, val) {
       if (val && typeof val === "object") {
@@ -9578,9 +9610,9 @@ var require_applyReviver = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/toJS.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/toJS.js
 var require_toJS = __commonJS({
-  "node_modules/yaml/dist/nodes/toJS.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/toJS.js"(exports2) {
     "use strict";
     var identity = require_identity();
     function toJS(value, arg, ctx) {
@@ -9608,9 +9640,9 @@ var require_toJS = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Node.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Node.js
 var require_Node = __commonJS({
-  "node_modules/yaml/dist/nodes/Node.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Node.js"(exports2) {
     "use strict";
     var applyReviver = require_applyReviver();
     var identity = require_identity();
@@ -9649,9 +9681,9 @@ var require_Node = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Alias.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Alias.js
 var require_Alias = __commonJS({
-  "node_modules/yaml/dist/nodes/Alias.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Alias.js"(exports2) {
     "use strict";
     var anchors = require_anchors();
     var visit = require_visit();
@@ -9710,7 +9742,7 @@ var require_Alias = __commonJS({
           toJS.toJS(source, null, ctx);
           data = anchors2.get(source);
         }
-        if (!data || data.res === void 0) {
+        if (data?.res === void 0) {
           const msg = "This should not happen: Alias anchor was not resolved?";
           throw new ReferenceError(msg);
         }
@@ -9763,9 +9795,9 @@ var require_Alias = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Scalar.js
 var require_Scalar = __commonJS({
-  "node_modules/yaml/dist/nodes/Scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Scalar.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Node = require_Node();
@@ -9793,9 +9825,9 @@ var require_Scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/createNode.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/createNode.js
 var require_createNode = __commonJS({
-  "node_modules/yaml/dist/doc/createNode.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/createNode.js"(exports2) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -9868,9 +9900,9 @@ var require_createNode = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Collection.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Collection.js
 var require_Collection = __commonJS({
-  "node_modules/yaml/dist/nodes/Collection.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Collection.js"(exports2) {
     "use strict";
     var createNode = require_createNode();
     var identity = require_identity();
@@ -10011,9 +10043,9 @@ var require_Collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyComment.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyComment.js
 var require_stringifyComment = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyComment.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyComment.js"(exports2) {
     "use strict";
     var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
     function indentComment(comment, indent) {
@@ -10028,9 +10060,9 @@ var require_stringifyComment = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/foldFlowLines.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/foldFlowLines.js
 var require_foldFlowLines = __commonJS({
-  "node_modules/yaml/dist/stringify/foldFlowLines.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/foldFlowLines.js"(exports2) {
     "use strict";
     var FOLD_FLOW = "flow";
     var FOLD_BLOCK = "block";
@@ -10164,9 +10196,9 @@ ${indent}${text.slice(fold + 1, end2)}`;
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyString.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyString.js
 var require_stringifyString = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyString.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyString.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var foldFlowLines = require_foldFlowLines();
@@ -10447,9 +10479,9 @@ ${indent}`);
   }
 });
 
-// node_modules/yaml/dist/stringify/stringify.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringify.js
 var require_stringify = __commonJS({
-  "node_modules/yaml/dist/stringify/stringify.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringify.js"(exports2) {
     "use strict";
     var anchors = require_anchors();
     var identity = require_identity();
@@ -10570,9 +10602,9 @@ ${ctx.indent}${str}`;
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyPair.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyPair.js
 var require_stringifyPair = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyPair.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyPair.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -10660,7 +10692,7 @@ ${indent}:`;
 ${stringifyComment.indentComment(cs, ctx.indent)}`;
         }
         if (valueStr === "" && !ctx.inFlow) {
-          if (ws === "\n")
+          if (ws === "\n" && valueComment)
             ws = "\n\n";
         } else {
           ws += `
@@ -10703,9 +10735,9 @@ ${ctx.indent}`;
   }
 });
 
-// node_modules/yaml/dist/log.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/log.js
 var require_log = __commonJS({
-  "node_modules/yaml/dist/log.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/log.js"(exports2) {
     "use strict";
     var node_process = require("process");
     function debug(logLevel, ...messages) {
@@ -10725,9 +10757,9 @@ var require_log = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/merge.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/merge.js
 var require_merge = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -10782,9 +10814,9 @@ var require_merge = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/addPairToJSMap.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/addPairToJSMap.js
 var require_addPairToJSMap = __commonJS({
-  "node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports2) {
     "use strict";
     var log = require_log();
     var merge = require_merge();
@@ -10846,9 +10878,9 @@ var require_addPairToJSMap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Pair.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Pair.js
 var require_Pair = __commonJS({
-  "node_modules/yaml/dist/nodes/Pair.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Pair.js"(exports2) {
     "use strict";
     var createNode = require_createNode();
     var stringifyPair = require_stringifyPair();
@@ -10886,9 +10918,9 @@ var require_Pair = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyCollection.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyCollection.js
 var require_stringifyCollection = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyCollection.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyCollection.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var stringify3 = require_stringify();
@@ -11030,9 +11062,9 @@ ${indent}${end}`;
   }
 });
 
-// node_modules/yaml/dist/nodes/YAMLMap.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLMap.js
 var require_YAMLMap = __commonJS({
-  "node_modules/yaml/dist/nodes/YAMLMap.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLMap.js"(exports2) {
     "use strict";
     var stringifyCollection = require_stringifyCollection();
     var addPairToJSMap = require_addPairToJSMap();
@@ -11174,9 +11206,9 @@ var require_YAMLMap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/map.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/map.js
 var require_map = __commonJS({
-  "node_modules/yaml/dist/schema/common/map.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/map.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var YAMLMap = require_YAMLMap();
@@ -11196,9 +11228,9 @@ var require_map = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/YAMLSeq.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLSeq.js
 var require_YAMLSeq = __commonJS({
-  "node_modules/yaml/dist/nodes/YAMLSeq.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLSeq.js"(exports2) {
     "use strict";
     var createNode = require_createNode();
     var stringifyCollection = require_stringifyCollection();
@@ -11312,9 +11344,9 @@ var require_YAMLSeq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/seq.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/seq.js
 var require_seq = __commonJS({
-  "node_modules/yaml/dist/schema/common/seq.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/seq.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var YAMLSeq = require_YAMLSeq();
@@ -11334,9 +11366,9 @@ var require_seq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/string.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/string.js
 var require_string = __commonJS({
-  "node_modules/yaml/dist/schema/common/string.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/string.js"(exports2) {
     "use strict";
     var stringifyString = require_stringifyString();
     var string = {
@@ -11353,9 +11385,9 @@ var require_string = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/null.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/null.js
 var require_null = __commonJS({
-  "node_modules/yaml/dist/schema/common/null.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/null.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var nullTag = {
@@ -11371,9 +11403,9 @@ var require_null = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/bool.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/bool.js
 var require_bool = __commonJS({
-  "node_modules/yaml/dist/schema/core/bool.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/bool.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var boolTag = {
@@ -11395,9 +11427,9 @@ var require_bool = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyNumber.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyNumber.js
 var require_stringifyNumber = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyNumber.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyNumber.js"(exports2) {
     "use strict";
     function stringifyNumber({ format, minFractionDigits, tag, value }) {
       if (typeof value === "bigint")
@@ -11405,7 +11437,7 @@ var require_stringifyNumber = __commonJS({
       const num = typeof value === "number" ? value : Number(value);
       if (!isFinite(num))
         return isNaN(num) ? ".nan" : num < 0 ? "-.inf" : ".inf";
-      let n = JSON.stringify(value);
+      let n = Object.is(value, -0) ? "-0" : JSON.stringify(value);
       if (!format && minFractionDigits && (!tag || tag === "tag:yaml.org,2002:float") && /^\d/.test(n)) {
         let i = n.indexOf(".");
         if (i < 0) {
@@ -11422,9 +11454,9 @@ var require_stringifyNumber = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/float.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/float.js
 var require_float = __commonJS({
-  "node_modules/yaml/dist/schema/core/float.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/float.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -11468,9 +11500,9 @@ var require_float = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/int.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/int.js
 var require_int = __commonJS({
-  "node_modules/yaml/dist/schema/core/int.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/int.js"(exports2) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -11513,9 +11545,9 @@ var require_int = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/schema.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/schema.js
 var require_schema = __commonJS({
-  "node_modules/yaml/dist/schema/core/schema.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/schema.js"(exports2) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -11541,9 +11573,9 @@ var require_schema = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/json/schema.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/json/schema.js
 var require_schema2 = __commonJS({
-  "node_modules/yaml/dist/schema/json/schema.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/json/schema.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var map = require_map();
@@ -11608,9 +11640,9 @@ var require_schema2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/binary.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/binary.js
 var require_binary = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports2) {
     "use strict";
     var node_buffer = require("buffer");
     var Scalar = require_Scalar();
@@ -11674,9 +11706,9 @@ var require_binary = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/pairs.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/pairs.js
 var require_pairs = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -11752,9 +11784,9 @@ ${cn.comment}` : item.comment;
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/omap.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/omap.js
 var require_omap = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var toJS = require_toJS();
@@ -11830,9 +11862,9 @@ var require_omap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/bool.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/bool.js
 var require_bool2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     function boolStringify({ value, source }, ctx) {
@@ -11862,9 +11894,9 @@ var require_bool2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/float.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/float.js
 var require_float2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -11911,9 +11943,9 @@ var require_float2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/int.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/int.js
 var require_int2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports2) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -11990,9 +12022,9 @@ var require_int2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/set.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/set.js
 var require_set = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -12079,9 +12111,9 @@ var require_set = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
 var require_timestamp = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports2) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     function parseSexagesimal(str, asBigInt) {
@@ -12167,9 +12199,9 @@ var require_timestamp = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/schema.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/schema.js
 var require_schema3 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports2) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -12211,9 +12243,9 @@ var require_schema3 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/tags.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/tags.js
 var require_tags = __commonJS({
-  "node_modules/yaml/dist/schema/tags.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/tags.js"(exports2) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -12305,9 +12337,9 @@ var require_tags = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/Schema.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/Schema.js
 var require_Schema = __commonJS({
-  "node_modules/yaml/dist/schema/Schema.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/Schema.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var map = require_map();
@@ -12337,9 +12369,9 @@ var require_Schema = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyDocument.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyDocument.js
 var require_stringifyDocument = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyDocument.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyDocument.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var stringify3 = require_stringify();
@@ -12417,9 +12449,9 @@ var require_stringifyDocument = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/Document.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/Document.js
 var require_Document = __commonJS({
-  "node_modules/yaml/dist/doc/Document.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/Document.js"(exports2) {
     "use strict";
     var Alias = require_Alias();
     var Collection = require_Collection();
@@ -12726,9 +12758,9 @@ var require_Document = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/errors.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/errors.js
 var require_errors = __commonJS({
-  "node_modules/yaml/dist/errors.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/errors.js"(exports2) {
     "use strict";
     var YAMLError = class extends Error {
       constructor(name, pos, code, message) {
@@ -12773,7 +12805,7 @@ var require_errors = __commonJS({
       if (/[^ ]/.test(lineStr)) {
         let count = 1;
         const end = error.linePos[1];
-        if (end && end.line === line && end.col > col) {
+        if (end?.line === line && end.col > col) {
           count = Math.max(1, Math.min(end.col - col, 80 - ci));
         }
         const pointer = " ".repeat(ci) + "^".repeat(count);
@@ -12791,9 +12823,9 @@ ${pointer}
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-props.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-props.js
 var require_resolve_props = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-props.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-props.js"(exports2) {
     "use strict";
     function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
       let spaceBefore = false;
@@ -12925,9 +12957,9 @@ var require_resolve_props = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-contains-newline.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-contains-newline.js
 var require_util_contains_newline = __commonJS({
-  "node_modules/yaml/dist/compose/util-contains-newline.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-contains-newline.js"(exports2) {
     "use strict";
     function containsNewline(key) {
       if (!key)
@@ -12967,9 +12999,9 @@ var require_util_contains_newline = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-flow-indent-check.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-flow-indent-check.js
 var require_util_flow_indent_check = __commonJS({
-  "node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports2) {
     "use strict";
     var utilContainsNewline = require_util_contains_newline();
     function flowIndentCheck(indent, fc, onError) {
@@ -12985,9 +13017,9 @@ var require_util_flow_indent_check = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-map-includes.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-map-includes.js
 var require_util_map_includes = __commonJS({
-  "node_modules/yaml/dist/compose/util-map-includes.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-map-includes.js"(exports2) {
     "use strict";
     var identity = require_identity();
     function mapIncludes(ctx, items, search) {
@@ -13001,9 +13033,9 @@ var require_util_map_includes = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-map.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-map.js
 var require_resolve_block_map = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-map.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-map.js"(exports2) {
     "use strict";
     var Pair = require_Pair();
     var YAMLMap = require_YAMLMap();
@@ -13109,9 +13141,9 @@ var require_resolve_block_map = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-seq.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-seq.js
 var require_resolve_block_seq = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-seq.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-seq.js"(exports2) {
     "use strict";
     var YAMLSeq = require_YAMLSeq();
     var resolveProps = require_resolve_props();
@@ -13136,7 +13168,7 @@ var require_resolve_block_seq = __commonJS({
         });
         if (!props.found) {
           if (props.anchor || props.tag || value) {
-            if (value && value.type === "block-seq")
+            if (value?.type === "block-seq")
               onError(props.end, "BAD_INDENT", "All sequence items must start at the same column");
             else
               onError(offset, "MISSING_CHAR", "Sequence item without - indicator");
@@ -13160,9 +13192,9 @@ var require_resolve_block_seq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-end.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-end.js
 var require_resolve_end = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-end.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-end.js"(exports2) {
     "use strict";
     function resolveEnd(end, offset, reqSpace, onError) {
       let comment = "";
@@ -13203,9 +13235,9 @@ var require_resolve_end = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-flow-collection.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-collection.js
 var require_resolve_flow_collection = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -13333,7 +13365,7 @@ var require_resolve_flow_collection = __commonJS({
                 onError(valueProps.found, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit flow sequence key");
             }
           } else if (value) {
-            if ("source" in value && value.source && value.source[0] === ":")
+            if ("source" in value && value.source?.[0] === ":")
               onError(value, "MISSING_CHAR", `Missing space after : in ${fcName}`);
             else
               onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
@@ -13370,7 +13402,7 @@ var require_resolve_flow_collection = __commonJS({
       const expectedEnd = isMap ? "}" : "]";
       const [ce, ...ee] = fc.end;
       let cePos = offset;
-      if (ce && ce.source === expectedEnd)
+      if (ce?.source === expectedEnd)
         cePos = ce.offset + ce.source.length;
       else {
         const name = fcName[0].toUpperCase() + fcName.substring(1);
@@ -13397,9 +13429,9 @@ var require_resolve_flow_collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-collection.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-collection.js
 var require_compose_collection = __commonJS({
-  "node_modules/yaml/dist/compose/compose-collection.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-collection.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -13437,7 +13469,7 @@ var require_compose_collection = __commonJS({
       let tag = ctx.schema.tags.find((t) => t.tag === tagName && t.collection === expType);
       if (!tag) {
         const kt = ctx.schema.knownTags[tagName];
-        if (kt && kt.collection === expType) {
+        if (kt?.collection === expType) {
           ctx.schema.tags.push(Object.assign({}, kt, { default: false }));
           tag = kt;
         } else {
@@ -13462,9 +13494,9 @@ var require_compose_collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-scalar.js
 var require_resolve_block_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     function resolveBlockScalar(ctx, scalar, onError) {
@@ -13645,9 +13677,9 @@ var require_resolve_block_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-flow-scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-scalar.js
 var require_resolve_flow_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var resolveEnd = require_resolve_end();
@@ -13864,9 +13896,9 @@ var require_resolve_flow_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-scalar.js
 var require_compose_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/compose-scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-scalar.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -13945,9 +13977,9 @@ var require_compose_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-empty-scalar-position.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-empty-scalar-position.js
 var require_util_empty_scalar_position = __commonJS({
-  "node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports2) {
     "use strict";
     function emptyScalarPosition(offset, before, pos) {
       if (before) {
@@ -13975,9 +14007,9 @@ var require_util_empty_scalar_position = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-node.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-node.js
 var require_compose_node = __commonJS({
-  "node_modules/yaml/dist/compose/compose-node.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-node.js"(exports2) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -14076,9 +14108,9 @@ var require_compose_node = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-doc.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-doc.js
 var require_compose_doc = __commonJS({
-  "node_modules/yaml/dist/compose/compose-doc.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-doc.js"(exports2) {
     "use strict";
     var Document = require_Document();
     var composeNode = require_compose_node();
@@ -14119,9 +14151,9 @@ var require_compose_doc = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/composer.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/composer.js
 var require_composer = __commonJS({
-  "node_modules/yaml/dist/compose/composer.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/composer.js"(exports2) {
     "use strict";
     var node_process = require("process");
     var directives = require_directives();
@@ -14325,9 +14357,9 @@ ${end.comment}` : end.comment;
   }
 });
 
-// node_modules/yaml/dist/parse/cst-scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-scalar.js
 var require_cst_scalar = __commonJS({
-  "node_modules/yaml/dist/parse/cst-scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-scalar.js"(exports2) {
     "use strict";
     var resolveBlockScalar = require_resolve_block_scalar();
     var resolveFlowScalar = require_resolve_flow_scalar();
@@ -14510,9 +14542,9 @@ var require_cst_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst-stringify.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-stringify.js
 var require_cst_stringify = __commonJS({
-  "node_modules/yaml/dist/parse/cst-stringify.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-stringify.js"(exports2) {
     "use strict";
     var stringify3 = (cst) => "type" in cst ? stringifyToken(cst) : stringifyItem(cst);
     function stringifyToken(token) {
@@ -14571,9 +14603,9 @@ var require_cst_stringify = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst-visit.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-visit.js
 var require_cst_visit = __commonJS({
-  "node_modules/yaml/dist/parse/cst-visit.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-visit.js"(exports2) {
     "use strict";
     var BREAK = Symbol("break visit");
     var SKIP = Symbol("skip children");
@@ -14633,9 +14665,9 @@ var require_cst_visit = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst.js
 var require_cst = __commonJS({
-  "node_modules/yaml/dist/parse/cst.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst.js"(exports2) {
     "use strict";
     var cstScalar = require_cst_scalar();
     var cstStringify = require_cst_stringify();
@@ -14735,9 +14767,9 @@ var require_cst = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/lexer.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/lexer.js
 var require_lexer = __commonJS({
-  "node_modules/yaml/dist/parse/lexer.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/lexer.js"(exports2) {
     "use strict";
     var cst = require_cst();
     function isEmpty(ch) {
@@ -15314,9 +15346,9 @@ var require_lexer = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/line-counter.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/line-counter.js
 var require_line_counter = __commonJS({
-  "node_modules/yaml/dist/parse/line-counter.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/line-counter.js"(exports2) {
     "use strict";
     var LineCounter = class {
       constructor() {
@@ -15345,9 +15377,9 @@ var require_line_counter = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/parser.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/parser.js
 var require_parser = __commonJS({
-  "node_modules/yaml/dist/parse/parser.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/parser.js"(exports2) {
     "use strict";
     var node_process = require("process");
     var cst = require_cst();
@@ -15535,7 +15567,7 @@ var require_parser = __commonJS({
       }
       *step() {
         const top = this.peek(1);
-        if (this.type === "doc-end" && (!top || top.type !== "doc-end")) {
+        if (this.type === "doc-end" && top?.type !== "doc-end") {
           while (this.stack.length > 0)
             yield* this.pop();
           this.stack.push({
@@ -16013,7 +16045,7 @@ var require_parser = __commonJS({
           do {
             yield* this.pop();
             top = this.peek(1);
-          } while (top && top.type === "flow-collection");
+          } while (top?.type === "flow-collection");
         } else if (fc.end.length === 0) {
           switch (this.type) {
             case "comma":
@@ -16212,9 +16244,9 @@ var require_parser = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/public-api.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/public-api.js
 var require_public_api = __commonJS({
-  "node_modules/yaml/dist/public-api.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/public-api.js"(exports2) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -16309,9 +16341,9 @@ var require_public_api = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/index.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/index.js
 var require_dist = __commonJS({
-  "node_modules/yaml/dist/index.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/index.js"(exports2) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -16369,7 +16401,7 @@ __export(index_exports, {
 });
 module.exports = __toCommonJS(index_exports);
 
-// node_modules/@stainless-api/sdk/internal/tslib.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/tslib.mjs
 function __classPrivateFieldSet(receiver, state, value, kind, f) {
   if (kind === "m")
     throw new TypeError("Private method is not writable");
@@ -16387,7 +16419,7 @@ function __classPrivateFieldGet(receiver, state, kind, f) {
   return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 }
 
-// node_modules/@stainless-api/sdk/internal/utils/uuid.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/uuid.mjs
 var uuid4 = function() {
   const { crypto } = globalThis;
   if (crypto?.randomUUID) {
@@ -16399,7 +16431,7 @@ var uuid4 = function() {
   return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) => (+c ^ randomByte() & 15 >> +c / 4).toString(16));
 };
 
-// node_modules/@stainless-api/sdk/internal/errors.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/errors.mjs
 function isAbortError(err) {
   return typeof err === "object" && err !== null && // Spec-compliant fetch implementations
   ("name" in err && err.name === "AbortError" || // Expo fetch
@@ -16430,7 +16462,7 @@ var castToError = (err) => {
   return new Error(err);
 };
 
-// node_modules/@stainless-api/sdk/core/error.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/error.mjs
 var StainlessError = class extends Error {
 };
 var APIError = class _APIError extends StainlessError {
@@ -16519,7 +16551,7 @@ var RateLimitError = class extends APIError {
 var InternalServerError = class extends APIError {
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/values.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/values.mjs
 var startsWithSchemeRegexp = /^[a-z][a-z0-9+.-]*:/i;
 var isAbsoluteURL = (url) => {
   return startsWithSchemeRegexp.test(url);
@@ -16559,13 +16591,13 @@ var safeJSON = (text) => {
   }
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/sleep.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/sleep.mjs
 var sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-// node_modules/@stainless-api/sdk/version.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/version.mjs
 var VERSION = "0.1.0-alpha.19";
 
-// node_modules/@stainless-api/sdk/internal/detect-platform.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/detect-platform.mjs
 function getDetectedPlatform() {
   if (typeof Deno !== "undefined" && Deno.build != null) {
     return "deno";
@@ -16691,7 +16723,7 @@ var getPlatformHeaders = () => {
   return _platformHeaders ?? (_platformHeaders = getPlatformProperties());
 };
 
-// node_modules/@stainless-api/sdk/internal/shims.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/shims.mjs
 function getDefaultFetch() {
   if (typeof fetch !== "undefined") {
     return fetch;
@@ -16736,7 +16768,7 @@ async function CancelReadableStream(stream) {
   await cancelPromise;
 }
 
-// node_modules/@stainless-api/sdk/internal/request-options.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/request-options.mjs
 var FallbackEncoder = ({ headers, body }) => {
   return {
     bodyHeaders: {
@@ -16746,7 +16778,7 @@ var FallbackEncoder = ({ headers, body }) => {
   };
 };
 
-// node_modules/@stainless-api/sdk/internal/qs/formats.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/qs/formats.mjs
 var default_format = "RFC3986";
 var default_formatter = (v) => String(v);
 var formatters = {
@@ -16755,7 +16787,7 @@ var formatters = {
 };
 var RFC1738 = "RFC1738";
 
-// node_modules/@stainless-api/sdk/internal/qs/utils.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/qs/utils.mjs
 var has = (obj, key) => (has = Object.hasOwn ?? Function.prototype.call.bind(Object.prototype.hasOwnProperty), has(obj, key));
 var hex_table = /* @__PURE__ */ (() => {
   const array = [];
@@ -16834,7 +16866,7 @@ function maybe_map(val, fn) {
   return fn(val);
 }
 
-// node_modules/@stainless-api/sdk/internal/qs/stringify.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/qs/stringify.mjs
 var array_prefix_generators = {
   brackets(prefix) {
     return String(prefix) + "[]";
@@ -17112,7 +17144,7 @@ function stringify(object, opts = {}) {
   return joined.length > 0 ? prefix + joined : "";
 }
 
-// node_modules/@stainless-api/sdk/internal/utils/log.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/log.mjs
 var levelNumbers = {
   off: 0,
   error: 200,
@@ -17185,7 +17217,7 @@ var formatRequestDetails = (details) => {
   return details;
 };
 
-// node_modules/@stainless-api/sdk/internal/parse.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/parse.mjs
 async function defaultParseResponse(client, props) {
   const { response, requestLogID, retryOfRequestLogID, startTime } = props;
   const body = await (async () => {
@@ -17215,7 +17247,7 @@ async function defaultParseResponse(client, props) {
   return body;
 }
 
-// node_modules/@stainless-api/sdk/core/api-promise.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/api-promise.mjs
 var _APIPromise_client;
 var APIPromise = class _APIPromise extends Promise {
   constructor(client, responsePromise, parseResponse = defaultParseResponse) {
@@ -17276,7 +17308,7 @@ var APIPromise = class _APIPromise extends Promise {
 };
 _APIPromise_client = /* @__PURE__ */ new WeakMap();
 
-// node_modules/@stainless-api/sdk/core/pagination.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/pagination.mjs
 var _AbstractPage_client;
 var AbstractPage = class {
   constructor(client, response, body, options) {
@@ -17357,7 +17389,7 @@ var Page = class extends AbstractPage {
   }
 };
 
-// node_modules/@stainless-api/sdk/internal/uploads.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/uploads.mjs
 var checkFileSupport = () => {
   if (typeof File === "undefined") {
     const { process: process2 } = globalThis;
@@ -17374,7 +17406,7 @@ function getName(value) {
 }
 var isAsyncIterable = (value) => value != null && typeof value === "object" && typeof value[Symbol.asyncIterator] === "function";
 
-// node_modules/@stainless-api/sdk/internal/to-file.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/to-file.mjs
 var isBlobLike = (value) => value != null && typeof value === "object" && typeof value.size === "number" && typeof value.type === "string" && typeof value.text === "function" && typeof value.slice === "function" && typeof value.arrayBuffer === "function";
 var isFileLike = (value) => value != null && typeof value === "object" && typeof value.name === "string" && typeof value.lastModified === "number" && isBlobLike(value);
 var isResponseLike = (value) => value != null && typeof value === "object" && typeof value.url === "string" && typeof value.blob === "function";
@@ -17426,14 +17458,14 @@ function propsForError(value) {
   return `; props: [${props.map((p) => `"${p}"`).join(", ")}]`;
 }
 
-// node_modules/@stainless-api/sdk/core/resource.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/resource.mjs
 var APIResource = class {
   constructor(client) {
     this._client = client;
   }
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/path.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/path.mjs
 function encodeURIPath(str) {
   return str.replace(/[^A-Za-z0-9\-._~!$&'()*+,;=:@]+/g, encodeURIComponent);
 }
@@ -17488,7 +17520,7 @@ ${underline}`);
 };
 var path = /* @__PURE__ */ createPathTagFunction(encodeURIPath);
 
-// node_modules/@stainless-api/sdk/resources/builds/diagnostics.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/builds/diagnostics.mjs
 var Diagnostics = class extends APIResource {
   /**
    * Get the list of diagnostics for a given build.
@@ -17504,7 +17536,7 @@ var Diagnostics = class extends APIResource {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/builds/target-outputs.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/builds/target-outputs.mjs
 var TargetOutputs = class extends APIResource {
   /**
    * Retrieve a method to download an output for a given build target.
@@ -17523,7 +17555,7 @@ var TargetOutputs = class extends APIResource {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/builds/builds.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/builds/builds.mjs
 var Builds = class extends APIResource {
   constructor() {
     super(...arguments);
@@ -17575,7 +17607,7 @@ var Builds = class extends APIResource {
 Builds.Diagnostics = Diagnostics;
 Builds.TargetOutputs = TargetOutputs;
 
-// node_modules/@stainless-api/sdk/resources/orgs.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/orgs.mjs
 var Orgs = class extends APIResource {
   /**
    * Retrieve an organization by name.
@@ -17591,7 +17623,7 @@ var Orgs = class extends APIResource {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/projects/branches.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/projects/branches.mjs
 var Branches = class extends APIResource {
   /**
    * Create a new branch for a project.
@@ -17656,7 +17688,7 @@ var Branches = class extends APIResource {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/projects/configs.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/projects/configs.mjs
 var Configs = class extends APIResource {
   /**
    * Retrieve the configuration files for a given project.
@@ -17674,7 +17706,7 @@ var Configs = class extends APIResource {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/projects/projects.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/projects/projects.mjs
 var Projects = class extends APIResource {
   constructor() {
     super(...arguments);
@@ -17711,7 +17743,7 @@ var Projects = class extends APIResource {
 Projects.Branches = Branches;
 Projects.Configs = Configs;
 
-// node_modules/@stainless-api/sdk/internal/headers.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/headers.mjs
 var brand_privateNullableHeaders = /* @__PURE__ */ Symbol("brand.privateNullableHeaders");
 function* iterateHeaders(headers) {
   if (!headers)
@@ -17774,7 +17806,7 @@ var buildHeaders = (newHeaders) => {
   return { [brand_privateNullableHeaders]: true, values: targetHeaders, nulls: nullHeaders };
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/env.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/env.mjs
 var readEnv = (env) => {
   if (typeof globalThis.process !== "undefined") {
     return globalThis.process.env?.[env]?.trim() ?? void 0;
@@ -17785,7 +17817,7 @@ var readEnv = (env) => {
   return void 0;
 };
 
-// node_modules/@stainless-api/sdk/lib/unwrap.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/lib/unwrap.mjs
 async function unwrapFile(value) {
   if (value === null) {
     return null;
@@ -17797,7 +17829,7 @@ async function unwrapFile(value) {
   return response.text();
 }
 
-// node_modules/@stainless-api/sdk/client.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/client.mjs
 var _Stainless_instances;
 var _a;
 var _Stainless_encoder;
@@ -18256,10 +18288,10 @@ var package_default = {
   }
 };
 
-// node_modules/@stainless-api/github-internal/lib/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/lib/secrets.mjs
 var import_libsodium_wrappers = __toESM(require_libsodium_wrappers(), 1);
 
-// node_modules/@stainless-api/github-internal/lib/auth.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/lib/auth.mjs
 var import_jsonwebtoken = __toESM(require_jsonwebtoken(), 1);
 
 // src/compat/platform.ts

--- a/dist/merge.js
+++ b/dist/merge.js
@@ -25,9 +25,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/libsodium/dist/modules/libsodium.js
+// node_modules/.pnpm/libsodium@0.7.15/node_modules/libsodium/dist/modules/libsodium.js
 var require_libsodium = __commonJS({
-  "node_modules/libsodium/dist/modules/libsodium.js"(exports2, module2) {
+  "node_modules/.pnpm/libsodium@0.7.15/node_modules/libsodium/dist/modules/libsodium.js"(exports2, module2) {
     !(function(A) {
       function I(A2) {
         "use strict";
@@ -2631,9 +2631,9 @@ var require_libsodium = __commonJS({
   }
 });
 
-// node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js
+// node_modules/.pnpm/libsodium-wrappers@0.7.15/node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js
 var require_libsodium_wrappers = __commonJS({
-  "node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js"(exports2) {
+  "node_modules/.pnpm/libsodium-wrappers@0.7.15/node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js"(exports2) {
     !(function(e) {
       function a(e2, a2) {
         "use strict";
@@ -5234,9 +5234,9 @@ var require_libsodium_wrappers = __commonJS({
   }
 });
 
-// node_modules/safe-buffer/index.js
+// node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer/index.js
 var require_safe_buffer = __commonJS({
-  "node_modules/safe-buffer/index.js"(exports2, module2) {
+  "node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer/index.js"(exports2, module2) {
     var buffer = require("buffer");
     var Buffer2 = buffer.Buffer;
     function copyProps(src, dst) {
@@ -5292,9 +5292,9 @@ var require_safe_buffer = __commonJS({
   }
 });
 
-// node_modules/jws/lib/data-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/data-stream.js
 var require_data_stream = __commonJS({
-  "node_modules/jws/lib/data-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/data-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var Stream = require("stream");
     var util = require("util");
@@ -5340,9 +5340,9 @@ var require_data_stream = __commonJS({
   }
 });
 
-// node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js
+// node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js
 var require_param_bytes_for_alg = __commonJS({
-  "node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js"(exports2, module2) {
+  "node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js"(exports2, module2) {
     "use strict";
     function getParamSize(keySize) {
       var result = (keySize / 8 | 0) + (keySize % 8 === 0 ? 0 : 1);
@@ -5364,9 +5364,9 @@ var require_param_bytes_for_alg = __commonJS({
   }
 });
 
-// node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js
+// node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js
 var require_ecdsa_sig_formatter = __commonJS({
-  "node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js"(exports2, module2) {
+  "node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js"(exports2, module2) {
     "use strict";
     var Buffer2 = require_safe_buffer().Buffer;
     var getParamBytesForAlg = require_param_bytes_for_alg();
@@ -5504,9 +5504,9 @@ var require_ecdsa_sig_formatter = __commonJS({
   }
 });
 
-// node_modules/buffer-equal-constant-time/index.js
+// node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time/index.js
 var require_buffer_equal_constant_time = __commonJS({
-  "node_modules/buffer-equal-constant-time/index.js"(exports2, module2) {
+  "node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time/index.js"(exports2, module2) {
     "use strict";
     var Buffer2 = require("buffer").Buffer;
     var SlowBuffer = require("buffer").SlowBuffer;
@@ -5538,9 +5538,9 @@ var require_buffer_equal_constant_time = __commonJS({
   }
 });
 
-// node_modules/jwa/index.js
+// node_modules/.pnpm/jwa@2.0.1/node_modules/jwa/index.js
 var require_jwa = __commonJS({
-  "node_modules/jwa/index.js"(exports2, module2) {
+  "node_modules/.pnpm/jwa@2.0.1/node_modules/jwa/index.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var crypto2 = require("crypto");
     var formatEcdsa = require_ecdsa_sig_formatter();
@@ -5749,7 +5749,7 @@ var require_jwa = __commonJS({
         es: createECDSAVerifer,
         none: createNoneVerifier
       };
-      var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/i);
+      var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/);
       if (!match)
         throw typeError(MSG_INVALID_ALGORITHM, algorithm);
       var algo = (match[1] || match[3]).toLowerCase();
@@ -5762,9 +5762,9 @@ var require_jwa = __commonJS({
   }
 });
 
-// node_modules/jws/lib/tostring.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/tostring.js
 var require_tostring = __commonJS({
-  "node_modules/jws/lib/tostring.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/tostring.js"(exports2, module2) {
     var Buffer2 = require("buffer").Buffer;
     module2.exports = function toString(obj) {
       if (typeof obj === "string")
@@ -5776,9 +5776,9 @@ var require_tostring = __commonJS({
   }
 });
 
-// node_modules/jws/lib/sign-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/sign-stream.js
 var require_sign_stream = __commonJS({
-  "node_modules/jws/lib/sign-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/sign-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var DataStream = require_data_stream();
     var jwa = require_jwa();
@@ -5805,7 +5805,12 @@ var require_sign_stream = __commonJS({
       return util.format("%s.%s", securedInput, signature);
     }
     function SignStream(opts) {
-      var secret = opts.secret || opts.privateKey || opts.key;
+      var secret = opts.secret;
+      secret = secret == null ? opts.privateKey : secret;
+      secret = secret == null ? opts.key : secret;
+      if (/^hs/i.test(opts.header.alg) === true && secret == null) {
+        throw new TypeError("secret must be a string or buffer or a KeyObject");
+      }
       var secretStream = new DataStream(secret);
       this.readable = true;
       this.header = opts.header;
@@ -5846,9 +5851,9 @@ var require_sign_stream = __commonJS({
   }
 });
 
-// node_modules/jws/lib/verify-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/verify-stream.js
 var require_verify_stream = __commonJS({
-  "node_modules/jws/lib/verify-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/verify-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var DataStream = require_data_stream();
     var jwa = require_jwa();
@@ -5917,7 +5922,12 @@ var require_verify_stream = __commonJS({
     }
     function VerifyStream(opts) {
       opts = opts || {};
-      var secretOrKey = opts.secret || opts.publicKey || opts.key;
+      var secretOrKey = opts.secret;
+      secretOrKey = secretOrKey == null ? opts.publicKey : secretOrKey;
+      secretOrKey = secretOrKey == null ? opts.key : secretOrKey;
+      if (/^hs/i.test(opts.algorithm) === true && secretOrKey == null) {
+        throw new TypeError("secret must be a string or buffer or a KeyObject");
+      }
       var secretStream = new DataStream(secretOrKey);
       this.readable = true;
       this.algorithm = opts.algorithm;
@@ -5956,9 +5966,9 @@ var require_verify_stream = __commonJS({
   }
 });
 
-// node_modules/jws/index.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/index.js
 var require_jws = __commonJS({
-  "node_modules/jws/index.js"(exports2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/index.js"(exports2) {
     var SignStream = require_sign_stream();
     var VerifyStream = require_verify_stream();
     var ALGORITHMS = [
@@ -5989,9 +5999,9 @@ var require_jws = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/decode.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/decode.js
 var require_decode = __commonJS({
-  "node_modules/jsonwebtoken/decode.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/decode.js"(exports2, module2) {
     var jws = require_jws();
     module2.exports = function(jwt, options) {
       options = options || {};
@@ -6021,9 +6031,9 @@ var require_decode = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/JsonWebTokenError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/JsonWebTokenError.js
 var require_JsonWebTokenError = __commonJS({
-  "node_modules/jsonwebtoken/lib/JsonWebTokenError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/JsonWebTokenError.js"(exports2, module2) {
     var JsonWebTokenError = function(message, error) {
       Error.call(this, message);
       if (Error.captureStackTrace) {
@@ -6039,9 +6049,9 @@ var require_JsonWebTokenError = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/NotBeforeError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/NotBeforeError.js
 var require_NotBeforeError = __commonJS({
-  "node_modules/jsonwebtoken/lib/NotBeforeError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/NotBeforeError.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var NotBeforeError = function(message, date) {
       JsonWebTokenError.call(this, message);
@@ -6054,9 +6064,9 @@ var require_NotBeforeError = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/TokenExpiredError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/TokenExpiredError.js
 var require_TokenExpiredError = __commonJS({
-  "node_modules/jsonwebtoken/lib/TokenExpiredError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/TokenExpiredError.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var TokenExpiredError = function(message, expiredAt) {
       JsonWebTokenError.call(this, message);
@@ -6069,9 +6079,9 @@ var require_TokenExpiredError = __commonJS({
   }
 });
 
-// node_modules/ms/index.js
+// node_modules/.pnpm/ms@2.1.3/node_modules/ms/index.js
 var require_ms = __commonJS({
-  "node_modules/ms/index.js"(exports2, module2) {
+  "node_modules/.pnpm/ms@2.1.3/node_modules/ms/index.js"(exports2, module2) {
     var s = 1e3;
     var m = s * 60;
     var h = m * 60;
@@ -6185,9 +6195,9 @@ var require_ms = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/timespan.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/timespan.js
 var require_timespan = __commonJS({
-  "node_modules/jsonwebtoken/lib/timespan.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/timespan.js"(exports2, module2) {
     var ms = require_ms();
     module2.exports = function(time, iat) {
       var timestamp = iat || Math.floor(Date.now() / 1e3);
@@ -6206,9 +6216,9 @@ var require_timespan = __commonJS({
   }
 });
 
-// node_modules/semver/internal/constants.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/constants.js
 var require_constants = __commonJS({
-  "node_modules/semver/internal/constants.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/constants.js"(exports2, module2) {
     "use strict";
     var SEMVER_SPEC_VERSION = "2.0.0";
     var MAX_LENGTH = 256;
@@ -6238,9 +6248,9 @@ var require_constants = __commonJS({
   }
 });
 
-// node_modules/semver/internal/debug.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/debug.js
 var require_debug = __commonJS({
-  "node_modules/semver/internal/debug.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/debug.js"(exports2, module2) {
     "use strict";
     var debug = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
     };
@@ -6248,9 +6258,9 @@ var require_debug = __commonJS({
   }
 });
 
-// node_modules/semver/internal/re.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/re.js
 var require_re = __commonJS({
-  "node_modules/semver/internal/re.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/re.js"(exports2, module2) {
     "use strict";
     var {
       MAX_SAFE_COMPONENT_LENGTH,
@@ -6336,9 +6346,9 @@ var require_re = __commonJS({
   }
 });
 
-// node_modules/semver/internal/parse-options.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/parse-options.js
 var require_parse_options = __commonJS({
-  "node_modules/semver/internal/parse-options.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/parse-options.js"(exports2, module2) {
     "use strict";
     var looseOption = Object.freeze({ loose: true });
     var emptyOpts = Object.freeze({});
@@ -6355,12 +6365,15 @@ var require_parse_options = __commonJS({
   }
 });
 
-// node_modules/semver/internal/identifiers.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/identifiers.js
 var require_identifiers = __commonJS({
-  "node_modules/semver/internal/identifiers.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/identifiers.js"(exports2, module2) {
     "use strict";
     var numeric = /^[0-9]+$/;
     var compareIdentifiers = (a, b) => {
+      if (typeof a === "number" && typeof b === "number") {
+        return a === b ? 0 : a < b ? -1 : 1;
+      }
       const anum = numeric.test(a);
       const bnum = numeric.test(b);
       if (anum && bnum) {
@@ -6377,9 +6390,9 @@ var require_identifiers = __commonJS({
   }
 });
 
-// node_modules/semver/classes/semver.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js
 var require_semver = __commonJS({
-  "node_modules/semver/classes/semver.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js"(exports2, module2) {
     "use strict";
     var debug = require_debug();
     var { MAX_LENGTH, MAX_SAFE_INTEGER } = require_constants();
@@ -6467,7 +6480,25 @@ var require_semver = __commonJS({
         if (!(other instanceof _SemVer)) {
           other = new _SemVer(other, this.options);
         }
-        return compareIdentifiers(this.major, other.major) || compareIdentifiers(this.minor, other.minor) || compareIdentifiers(this.patch, other.patch);
+        if (this.major < other.major) {
+          return -1;
+        }
+        if (this.major > other.major) {
+          return 1;
+        }
+        if (this.minor < other.minor) {
+          return -1;
+        }
+        if (this.minor > other.minor) {
+          return 1;
+        }
+        if (this.patch < other.patch) {
+          return -1;
+        }
+        if (this.patch > other.patch) {
+          return 1;
+        }
+        return 0;
       }
       comparePre(other) {
         if (!(other instanceof _SemVer)) {
@@ -6638,9 +6669,9 @@ var require_semver = __commonJS({
   }
 });
 
-// node_modules/semver/functions/parse.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/parse.js
 var require_parse = __commonJS({
-  "node_modules/semver/functions/parse.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/parse.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var parse = (version, options, throwErrors = false) => {
@@ -6660,9 +6691,9 @@ var require_parse = __commonJS({
   }
 });
 
-// node_modules/semver/functions/valid.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/valid.js
 var require_valid = __commonJS({
-  "node_modules/semver/functions/valid.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/valid.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var valid = (version, options) => {
@@ -6673,9 +6704,9 @@ var require_valid = __commonJS({
   }
 });
 
-// node_modules/semver/functions/clean.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/clean.js
 var require_clean = __commonJS({
-  "node_modules/semver/functions/clean.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/clean.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var clean = (version, options) => {
@@ -6686,9 +6717,9 @@ var require_clean = __commonJS({
   }
 });
 
-// node_modules/semver/functions/inc.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/inc.js
 var require_inc = __commonJS({
-  "node_modules/semver/functions/inc.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/inc.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var inc = (version, release, options, identifier, identifierBase) => {
@@ -6710,9 +6741,9 @@ var require_inc = __commonJS({
   }
 });
 
-// node_modules/semver/functions/diff.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/diff.js
 var require_diff = __commonJS({
-  "node_modules/semver/functions/diff.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/diff.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var diff = (version1, version2) => {
@@ -6754,9 +6785,9 @@ var require_diff = __commonJS({
   }
 });
 
-// node_modules/semver/functions/major.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/major.js
 var require_major = __commonJS({
-  "node_modules/semver/functions/major.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/major.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var major = (a, loose) => new SemVer(a, loose).major;
@@ -6764,9 +6795,9 @@ var require_major = __commonJS({
   }
 });
 
-// node_modules/semver/functions/minor.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/minor.js
 var require_minor = __commonJS({
-  "node_modules/semver/functions/minor.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/minor.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var minor = (a, loose) => new SemVer(a, loose).minor;
@@ -6774,9 +6805,9 @@ var require_minor = __commonJS({
   }
 });
 
-// node_modules/semver/functions/patch.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/patch.js
 var require_patch = __commonJS({
-  "node_modules/semver/functions/patch.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/patch.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var patch = (a, loose) => new SemVer(a, loose).patch;
@@ -6784,9 +6815,9 @@ var require_patch = __commonJS({
   }
 });
 
-// node_modules/semver/functions/prerelease.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/prerelease.js
 var require_prerelease = __commonJS({
-  "node_modules/semver/functions/prerelease.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/prerelease.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var prerelease = (version, options) => {
@@ -6797,9 +6828,9 @@ var require_prerelease = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js
 var require_compare = __commonJS({
-  "node_modules/semver/functions/compare.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var compare = (a, b, loose) => new SemVer(a, loose).compare(new SemVer(b, loose));
@@ -6807,9 +6838,9 @@ var require_compare = __commonJS({
   }
 });
 
-// node_modules/semver/functions/rcompare.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rcompare.js
 var require_rcompare = __commonJS({
-  "node_modules/semver/functions/rcompare.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rcompare.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var rcompare = (a, b, loose) => compare(b, a, loose);
@@ -6817,9 +6848,9 @@ var require_rcompare = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare-loose.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-loose.js
 var require_compare_loose = __commonJS({
-  "node_modules/semver/functions/compare-loose.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-loose.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var compareLoose = (a, b) => compare(a, b, true);
@@ -6827,9 +6858,9 @@ var require_compare_loose = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare-build.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-build.js
 var require_compare_build = __commonJS({
-  "node_modules/semver/functions/compare-build.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-build.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var compareBuild = (a, b, loose) => {
@@ -6841,9 +6872,9 @@ var require_compare_build = __commonJS({
   }
 });
 
-// node_modules/semver/functions/sort.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/sort.js
 var require_sort = __commonJS({
-  "node_modules/semver/functions/sort.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/sort.js"(exports2, module2) {
     "use strict";
     var compareBuild = require_compare_build();
     var sort = (list, loose) => list.sort((a, b) => compareBuild(a, b, loose));
@@ -6851,9 +6882,9 @@ var require_sort = __commonJS({
   }
 });
 
-// node_modules/semver/functions/rsort.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rsort.js
 var require_rsort = __commonJS({
-  "node_modules/semver/functions/rsort.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rsort.js"(exports2, module2) {
     "use strict";
     var compareBuild = require_compare_build();
     var rsort = (list, loose) => list.sort((a, b) => compareBuild(b, a, loose));
@@ -6861,9 +6892,9 @@ var require_rsort = __commonJS({
   }
 });
 
-// node_modules/semver/functions/gt.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gt.js
 var require_gt = __commonJS({
-  "node_modules/semver/functions/gt.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gt.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var gt = (a, b, loose) => compare(a, b, loose) > 0;
@@ -6871,9 +6902,9 @@ var require_gt = __commonJS({
   }
 });
 
-// node_modules/semver/functions/lt.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lt.js
 var require_lt = __commonJS({
-  "node_modules/semver/functions/lt.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lt.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var lt = (a, b, loose) => compare(a, b, loose) < 0;
@@ -6881,9 +6912,9 @@ var require_lt = __commonJS({
   }
 });
 
-// node_modules/semver/functions/eq.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/eq.js
 var require_eq = __commonJS({
-  "node_modules/semver/functions/eq.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/eq.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var eq = (a, b, loose) => compare(a, b, loose) === 0;
@@ -6891,9 +6922,9 @@ var require_eq = __commonJS({
   }
 });
 
-// node_modules/semver/functions/neq.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/neq.js
 var require_neq = __commonJS({
-  "node_modules/semver/functions/neq.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/neq.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var neq = (a, b, loose) => compare(a, b, loose) !== 0;
@@ -6901,9 +6932,9 @@ var require_neq = __commonJS({
   }
 });
 
-// node_modules/semver/functions/gte.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gte.js
 var require_gte = __commonJS({
-  "node_modules/semver/functions/gte.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gte.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var gte = (a, b, loose) => compare(a, b, loose) >= 0;
@@ -6911,9 +6942,9 @@ var require_gte = __commonJS({
   }
 });
 
-// node_modules/semver/functions/lte.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lte.js
 var require_lte = __commonJS({
-  "node_modules/semver/functions/lte.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lte.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var lte = (a, b, loose) => compare(a, b, loose) <= 0;
@@ -6921,9 +6952,9 @@ var require_lte = __commonJS({
   }
 });
 
-// node_modules/semver/functions/cmp.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/cmp.js
 var require_cmp = __commonJS({
-  "node_modules/semver/functions/cmp.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/cmp.js"(exports2, module2) {
     "use strict";
     var eq = require_eq();
     var neq = require_neq();
@@ -6971,9 +7002,9 @@ var require_cmp = __commonJS({
   }
 });
 
-// node_modules/semver/functions/coerce.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/coerce.js
 var require_coerce = __commonJS({
-  "node_modules/semver/functions/coerce.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/coerce.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var parse = require_parse();
@@ -7017,9 +7048,9 @@ var require_coerce = __commonJS({
   }
 });
 
-// node_modules/semver/internal/lrucache.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/lrucache.js
 var require_lrucache = __commonJS({
-  "node_modules/semver/internal/lrucache.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/lrucache.js"(exports2, module2) {
     "use strict";
     var LRUCache = class {
       constructor() {
@@ -7055,9 +7086,9 @@ var require_lrucache = __commonJS({
   }
 });
 
-// node_modules/semver/classes/range.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/range.js
 var require_range = __commonJS({
-  "node_modules/semver/classes/range.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/range.js"(exports2, module2) {
     "use strict";
     var SPACE_CHARACTERS = /\s+/g;
     var Range = class _Range {
@@ -7228,6 +7259,7 @@ var require_range = __commonJS({
       return result;
     };
     var parseComparator = (comp, options) => {
+      comp = comp.replace(re[t.BUILD], "");
       debug("comp", comp, options);
       comp = replaceCarets(comp, options);
       debug("caret", comp);
@@ -7431,9 +7463,9 @@ var require_range = __commonJS({
   }
 });
 
-// node_modules/semver/classes/comparator.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/comparator.js
 var require_comparator = __commonJS({
-  "node_modules/semver/classes/comparator.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/comparator.js"(exports2, module2) {
     "use strict";
     var ANY = Symbol("SemVer ANY");
     var Comparator = class _Comparator {
@@ -7544,9 +7576,9 @@ var require_comparator = __commonJS({
   }
 });
 
-// node_modules/semver/functions/satisfies.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/satisfies.js
 var require_satisfies = __commonJS({
-  "node_modules/semver/functions/satisfies.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/satisfies.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var satisfies = (version, range, options) => {
@@ -7561,9 +7593,9 @@ var require_satisfies = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/to-comparators.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/to-comparators.js
 var require_to_comparators = __commonJS({
-  "node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var toComparators = (range, options) => new Range(range, options).set.map((comp) => comp.map((c) => c.value).join(" ").trim().split(" "));
@@ -7571,9 +7603,9 @@ var require_to_comparators = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/max-satisfying.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/max-satisfying.js
 var require_max_satisfying = __commonJS({
-  "node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7600,9 +7632,9 @@ var require_max_satisfying = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/min-satisfying.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-satisfying.js
 var require_min_satisfying = __commonJS({
-  "node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7629,9 +7661,9 @@ var require_min_satisfying = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/min-version.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-version.js
 var require_min_version = __commonJS({
-  "node_modules/semver/ranges/min-version.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-version.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7688,9 +7720,9 @@ var require_min_version = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/valid.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/valid.js
 var require_valid2 = __commonJS({
-  "node_modules/semver/ranges/valid.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/valid.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var validRange = (range, options) => {
@@ -7704,9 +7736,9 @@ var require_valid2 = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/outside.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/outside.js
 var require_outside = __commonJS({
-  "node_modules/semver/ranges/outside.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/outside.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Comparator = require_comparator();
@@ -7773,9 +7805,9 @@ var require_outside = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/gtr.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/gtr.js
 var require_gtr = __commonJS({
-  "node_modules/semver/ranges/gtr.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/gtr.js"(exports2, module2) {
     "use strict";
     var outside = require_outside();
     var gtr = (version, range, options) => outside(version, range, ">", options);
@@ -7783,9 +7815,9 @@ var require_gtr = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/ltr.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/ltr.js
 var require_ltr = __commonJS({
-  "node_modules/semver/ranges/ltr.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/ltr.js"(exports2, module2) {
     "use strict";
     var outside = require_outside();
     var ltr = (version, range, options) => outside(version, range, "<", options);
@@ -7793,9 +7825,9 @@ var require_ltr = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/intersects.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/intersects.js
 var require_intersects = __commonJS({
-  "node_modules/semver/ranges/intersects.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/intersects.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var intersects = (r1, r2, options) => {
@@ -7807,9 +7839,9 @@ var require_intersects = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/simplify.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/simplify.js
 var require_simplify = __commonJS({
-  "node_modules/semver/ranges/simplify.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/simplify.js"(exports2, module2) {
     "use strict";
     var satisfies = require_satisfies();
     var compare = require_compare();
@@ -7857,9 +7889,9 @@ var require_simplify = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/subset.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/subset.js
 var require_subset = __commonJS({
-  "node_modules/semver/ranges/subset.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/subset.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var Comparator = require_comparator();
@@ -8019,9 +8051,9 @@ var require_subset = __commonJS({
   }
 });
 
-// node_modules/semver/index.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/index.js
 var require_semver2 = __commonJS({
-  "node_modules/semver/index.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/index.js"(exports2, module2) {
     "use strict";
     var internalRe = require_re();
     var constants = require_constants();
@@ -8114,25 +8146,25 @@ var require_semver2 = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js
 var require_asymmetricKeyDetailsSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, ">=15.7.0");
   }
 });
 
-// node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js
 var require_rsaPssKeyDetailsSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, ">=16.9.0");
   }
 });
 
-// node_modules/jsonwebtoken/lib/validateAsymmetricKey.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/validateAsymmetricKey.js
 var require_validateAsymmetricKey = __commonJS({
-  "node_modules/jsonwebtoken/lib/validateAsymmetricKey.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/validateAsymmetricKey.js"(exports2, module2) {
     var ASYMMETRIC_KEY_DETAILS_SUPPORTED = require_asymmetricKeyDetailsSupported();
     var RSA_PSS_KEY_DETAILS_SUPPORTED = require_rsaPssKeyDetailsSupported();
     var allowedAlgorithmsForKeys = {
@@ -8183,17 +8215,17 @@ var require_validateAsymmetricKey = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/psSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/psSupported.js
 var require_psSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/psSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/psSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, "^6.12.0 || >=8.0.0");
   }
 });
 
-// node_modules/jsonwebtoken/verify.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/verify.js
 var require_verify = __commonJS({
-  "node_modules/jsonwebtoken/verify.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/verify.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var NotBeforeError = require_NotBeforeError();
     var TokenExpiredError = require_TokenExpiredError();
@@ -8406,9 +8438,9 @@ var require_verify = __commonJS({
   }
 });
 
-// node_modules/lodash.includes/index.js
+// node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes/index.js
 var require_lodash = __commonJS({
-  "node_modules/lodash.includes/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes/index.js"(exports2, module2) {
     var INFINITY = 1 / 0;
     var MAX_SAFE_INTEGER = 9007199254740991;
     var MAX_INTEGER = 17976931348623157e292;
@@ -8590,9 +8622,9 @@ var require_lodash = __commonJS({
   }
 });
 
-// node_modules/lodash.isboolean/index.js
+// node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean/index.js
 var require_lodash2 = __commonJS({
-  "node_modules/lodash.isboolean/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean/index.js"(exports2, module2) {
     var boolTag = "[object Boolean]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8606,9 +8638,9 @@ var require_lodash2 = __commonJS({
   }
 });
 
-// node_modules/lodash.isinteger/index.js
+// node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger/index.js
 var require_lodash3 = __commonJS({
-  "node_modules/lodash.isinteger/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger/index.js"(exports2, module2) {
     var INFINITY = 1 / 0;
     var MAX_INTEGER = 17976931348623157e292;
     var NAN = 0 / 0;
@@ -8670,9 +8702,9 @@ var require_lodash3 = __commonJS({
   }
 });
 
-// node_modules/lodash.isnumber/index.js
+// node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber/index.js
 var require_lodash4 = __commonJS({
-  "node_modules/lodash.isnumber/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber/index.js"(exports2, module2) {
     var numberTag = "[object Number]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8686,9 +8718,9 @@ var require_lodash4 = __commonJS({
   }
 });
 
-// node_modules/lodash.isplainobject/index.js
+// node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject/index.js
 var require_lodash5 = __commonJS({
-  "node_modules/lodash.isplainobject/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject/index.js"(exports2, module2) {
     var objectTag = "[object Object]";
     function isHostObject(value) {
       var result = false;
@@ -8730,9 +8762,9 @@ var require_lodash5 = __commonJS({
   }
 });
 
-// node_modules/lodash.isstring/index.js
+// node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring/index.js
 var require_lodash6 = __commonJS({
-  "node_modules/lodash.isstring/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring/index.js"(exports2, module2) {
     var stringTag = "[object String]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8747,9 +8779,9 @@ var require_lodash6 = __commonJS({
   }
 });
 
-// node_modules/lodash.once/index.js
+// node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once/index.js
 var require_lodash7 = __commonJS({
-  "node_modules/lodash.once/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once/index.js"(exports2, module2) {
     var FUNC_ERROR_TEXT = "Expected a function";
     var INFINITY = 1 / 0;
     var MAX_INTEGER = 17976931348623157e292;
@@ -8828,9 +8860,9 @@ var require_lodash7 = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/sign.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/sign.js
 var require_sign = __commonJS({
-  "node_modules/jsonwebtoken/sign.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/sign.js"(exports2, module2) {
     var timespan = require_timespan();
     var PS_SUPPORTED = require_psSupported();
     var validateAsymmetricKey = require_validateAsymmetricKey();
@@ -9053,9 +9085,9 @@ var require_sign = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/index.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/index.js
 var require_jsonwebtoken = __commonJS({
-  "node_modules/jsonwebtoken/index.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/index.js"(exports2, module2) {
     module2.exports = {
       decode: require_decode(),
       verify: require_verify(),
@@ -9067,9 +9099,9 @@ var require_jsonwebtoken = __commonJS({
   }
 });
 
-// node_modules/ts-dedent/dist/index.js
+// node_modules/.pnpm/ts-dedent@2.2.0/node_modules/ts-dedent/dist/index.js
 var require_dist = __commonJS({
-  "node_modules/ts-dedent/dist/index.js"(exports2) {
+  "node_modules/.pnpm/ts-dedent@2.2.0/node_modules/ts-dedent/dist/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.dedent = void 0;
@@ -9119,7 +9151,7 @@ var require_dist = __commonJS({
 // src/compat/index.ts
 var fs2 = __toESM(require("node:fs"));
 
-// node_modules/@stainless-api/github-internal/core/resource.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/core/resource.mjs
 var APIResource = /* @__PURE__ */ (() => {
   class APIResource3 {
     constructor(client) {
@@ -9130,7 +9162,7 @@ var APIResource = /* @__PURE__ */ (() => {
   return APIResource3;
 })();
 
-// node_modules/@stainless-api/github-internal/internal/tslib.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/tslib.mjs
 function __classPrivateFieldSet(receiver, state, value, kind, f) {
   if (kind === "m")
     throw new TypeError("Private method is not writable");
@@ -9148,7 +9180,7 @@ function __classPrivateFieldGet(receiver, state, kind, f) {
   return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 }
 
-// node_modules/@stainless-api/github-internal/internal/errors.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/errors.mjs
 function isAbortError(err) {
   return typeof err === "object" && err !== null && // Spec-compliant fetch implementations
   ("name" in err && err.name === "AbortError" || // Expo fetch
@@ -9179,7 +9211,7 @@ var castToError = (err) => {
   return new Error(err);
 };
 
-// node_modules/@stainless-api/github-internal/core/error.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/core/error.mjs
 var GitHubError = /* @__PURE__ */ (() => {
   class GitHubError2 extends Error {
   }
@@ -9271,7 +9303,7 @@ var RateLimitError = class extends APIError {
 var InternalServerError = class extends APIError {
 };
 
-// node_modules/@stainless-api/github-internal/internal/utils/values.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/utils/values.mjs
 var startsWithSchemeRegexp = /^[a-z][a-z0-9+.-]*:/i;
 var isAbsoluteURL = (url) => {
   return startsWithSchemeRegexp.test(url);
@@ -9311,7 +9343,7 @@ var safeJSON = (text) => {
   }
 };
 
-// node_modules/@stainless-api/github-internal/internal/utils/log.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/utils/log.mjs
 var levelNumbers = {
   off: 0,
   error: 200,
@@ -9384,7 +9416,7 @@ var formatRequestDetails = (details) => {
   return details;
 };
 
-// node_modules/@stainless-api/github-internal/internal/parse.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/parse.mjs
 async function defaultParseResponse(client, props) {
   const { response, requestLogID, retryOfRequestLogID, startTime } = props;
   const body = await (async () => {
@@ -9414,7 +9446,7 @@ async function defaultParseResponse(client, props) {
   return body;
 }
 
-// node_modules/@stainless-api/github-internal/core/api-promise.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/core/api-promise.mjs
 var _APIPromise_client;
 var APIPromise = /* @__PURE__ */ (() => {
   class APIPromise3 extends Promise {
@@ -9478,7 +9510,7 @@ var APIPromise = /* @__PURE__ */ (() => {
   return APIPromise3;
 })();
 
-// node_modules/@stainless-api/github-internal/core/pagination.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/core/pagination.mjs
 var _AbstractPage_client;
 var AbstractPage = /* @__PURE__ */ (() => {
   class AbstractPage3 {
@@ -9599,7 +9631,7 @@ var HypermediaPage = class extends AbstractPage {
   }
 };
 
-// node_modules/@stainless-api/github-internal/internal/headers.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/headers.mjs
 var brand_privateNullableHeaders = /* @__PURE__ */ Symbol("brand.privateNullableHeaders");
 function* iterateHeaders(headers) {
   if (!headers)
@@ -9662,7 +9694,7 @@ var buildHeaders = (newHeaders) => {
   return { [brand_privateNullableHeaders]: true, values: targetHeaders, nulls: nullHeaders };
 };
 
-// node_modules/@stainless-api/github-internal/internal/utils/path.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/utils/path.mjs
 function encodeURIPath(str) {
   return str.replace(/[^A-Za-z0-9\-._~!$&'()*+,;=:@]+/g, encodeURIComponent);
 }
@@ -9717,7 +9749,7 @@ ${underline}`);
 };
 var path = /* @__PURE__ */ createPathTagFunction(encodeURIPath);
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/comments/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/comments/reactions.mjs
 var BaseReactions = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -9794,7 +9826,7 @@ var BaseReactions = /* @__PURE__ */ (() => {
 var Reactions = class extends BaseReactions {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/comments/comments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/comments/comments.mjs
 var BaseComments = /* @__PURE__ */ (() => {
   class BaseComments7 extends APIResource {
     /**
@@ -9989,7 +10021,7 @@ var Comments = /* @__PURE__ */ (() => {
   return Comments7;
 })();
 
-// node_modules/@stainless-api/github-internal/internal/utils/uuid.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/utils/uuid.mjs
 var uuid4 = function() {
   const { crypto: crypto2 } = globalThis;
   if (crypto2?.randomUUID) {
@@ -10001,13 +10033,13 @@ var uuid4 = function() {
   return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) => (+c ^ randomByte() & 15 >> +c / 4).toString(16));
 };
 
-// node_modules/@stainless-api/github-internal/internal/utils/sleep.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/utils/sleep.mjs
 var sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-// node_modules/@stainless-api/github-internal/version.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/version.mjs
 var VERSION = "0.15.0";
 
-// node_modules/@stainless-api/github-internal/internal/detect-platform.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/detect-platform.mjs
 function getDetectedPlatform() {
   if (typeof Deno !== "undefined" && Deno.build != null) {
     return "deno";
@@ -10133,7 +10165,7 @@ var getPlatformHeaders = () => {
   return _platformHeaders ?? (_platformHeaders = getPlatformProperties());
 };
 
-// node_modules/@stainless-api/github-internal/internal/shims.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/shims.mjs
 function getDefaultFetch() {
   if (typeof fetch !== "undefined") {
     return fetch;
@@ -10178,7 +10210,7 @@ async function CancelReadableStream(stream) {
   await cancelPromise;
 }
 
-// node_modules/@stainless-api/github-internal/internal/request-options.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/request-options.mjs
 var FallbackEncoder = ({ headers, body }) => {
   return {
     bodyHeaders: {
@@ -10188,7 +10220,7 @@ var FallbackEncoder = ({ headers, body }) => {
   };
 };
 
-// node_modules/@stainless-api/github-internal/internal/qs/formats.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/qs/formats.mjs
 var default_format = "RFC3986";
 var default_formatter = (v) => String(v);
 var formatters = {
@@ -10197,7 +10229,7 @@ var formatters = {
 };
 var RFC1738 = "RFC1738";
 
-// node_modules/@stainless-api/github-internal/internal/qs/utils.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/qs/utils.mjs
 var has = (obj, key) => (has = Object.hasOwn ?? Function.prototype.call.bind(Object.prototype.hasOwnProperty), has(obj, key));
 var hex_table = /* @__PURE__ */ (() => {
   const array = [];
@@ -10276,7 +10308,7 @@ function maybe_map(val, fn) {
   return fn(val);
 }
 
-// node_modules/@stainless-api/github-internal/internal/qs/stringify.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/qs/stringify.mjs
 var array_prefix_generators = {
   brackets(prefix) {
     return String(prefix) + "[]";
@@ -10554,7 +10586,7 @@ function stringify(object, opts = {}) {
   return joined.length > 0 ? prefix + joined : "";
 }
 
-// node_modules/@stainless-api/github-internal/internal/uploads.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/uploads.mjs
 var checkFileSupport = () => {
   if (typeof File === "undefined") {
     const { process: process7 } = globalThis;
@@ -10571,7 +10603,7 @@ function getName(value) {
 }
 var isAsyncIterable = (value) => value != null && typeof value === "object" && typeof value[Symbol.asyncIterator] === "function";
 
-// node_modules/@stainless-api/github-internal/internal/to-file.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/to-file.mjs
 var isBlobLike = (value) => value != null && typeof value === "object" && typeof value.size === "number" && typeof value.type === "string" && typeof value.text === "function" && typeof value.slice === "function" && typeof value.arrayBuffer === "function";
 var isFileLike = (value) => value != null && typeof value === "object" && typeof value.name === "string" && typeof value.lastModified === "number" && isBlobLike(value);
 var isResponseLike = (value) => value != null && typeof value === "object" && typeof value.url === "string" && typeof value.blob === "function";
@@ -10623,7 +10655,7 @@ function propsForError(value) {
   return `; props: [${props.map((p) => `"${p}"`).join(", ")}]`;
 }
 
-// node_modules/@stainless-api/github-internal/resources/advisories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/advisories.mjs
 var BaseAdvisories = /* @__PURE__ */ (() => {
   class BaseAdvisories2 extends APIResource {
     /**
@@ -10654,7 +10686,7 @@ var BaseAdvisories = /* @__PURE__ */ (() => {
 var Advisories = class extends BaseAdvisories {
 };
 
-// node_modules/@stainless-api/github-internal/resources/app-manifests.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/app-manifests.mjs
 var BaseAppManifests = /* @__PURE__ */ (() => {
   class BaseAppManifests2 extends APIResource {
     /**
@@ -10674,7 +10706,7 @@ var BaseAppManifests = /* @__PURE__ */ (() => {
 var AppManifests = class extends BaseAppManifests {
 };
 
-// node_modules/@stainless-api/github-internal/resources/applications/token.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/applications/token.mjs
 var BaseToken = /* @__PURE__ */ (() => {
   class BaseToken2 extends APIResource {
     /**
@@ -10773,7 +10805,7 @@ var BaseToken = /* @__PURE__ */ (() => {
 var Token = class extends BaseToken {
 };
 
-// node_modules/@stainless-api/github-internal/resources/applications/applications.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/applications/applications.mjs
 var BaseApplications = /* @__PURE__ */ (() => {
   class BaseApplications2 extends APIResource {
     /**
@@ -10815,7 +10847,7 @@ var Applications = /* @__PURE__ */ (() => {
   return Applications2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/apps/hook/config.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/apps/hook/config.mjs
 var BaseConfig = /* @__PURE__ */ (() => {
   class BaseConfig4 extends APIResource {
     /**
@@ -10869,7 +10901,7 @@ var BaseConfig = /* @__PURE__ */ (() => {
 var Config = class extends BaseConfig {
 };
 
-// node_modules/@stainless-api/github-internal/resources/apps/hook/deliveries.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/apps/hook/deliveries.mjs
 var BaseDeliveries = /* @__PURE__ */ (() => {
   class BaseDeliveries4 extends APIResource {
     /**
@@ -10938,7 +10970,7 @@ var BaseDeliveries = /* @__PURE__ */ (() => {
 var Deliveries = class extends BaseDeliveries {
 };
 
-// node_modules/@stainless-api/github-internal/resources/apps/hook/hook.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/apps/hook/hook.mjs
 var BaseHook = /* @__PURE__ */ (() => {
   class BaseHook2 extends APIResource {
   }
@@ -10960,7 +10992,7 @@ var Hook = /* @__PURE__ */ (() => {
   return Hook2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/apps/installations/suspended.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/apps/installations/suspended.mjs
 var BaseSuspended = /* @__PURE__ */ (() => {
   class BaseSuspended2 extends APIResource {
     /**
@@ -11013,7 +11045,7 @@ var BaseSuspended = /* @__PURE__ */ (() => {
 var Suspended = class extends BaseSuspended {
 };
 
-// node_modules/@stainless-api/github-internal/resources/apps/installations/installations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/apps/installations/installations.mjs
 var BaseInstallations = /* @__PURE__ */ (() => {
   class BaseInstallations3 extends APIResource {
     /**
@@ -11133,7 +11165,7 @@ var Installations = /* @__PURE__ */ (() => {
   return Installations3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/apps/apps.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/apps/apps.mjs
 var BaseApps = /* @__PURE__ */ (() => {
   class BaseApps3 extends APIResource {
     /**
@@ -11202,7 +11234,7 @@ var Apps = /* @__PURE__ */ (() => {
   return Apps3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/assignments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/assignments.mjs
 var BaseAssignments = /* @__PURE__ */ (() => {
   class BaseAssignments2 extends APIResource {
     /**
@@ -11234,7 +11266,7 @@ var BaseAssignments = /* @__PURE__ */ (() => {
 var Assignments = class extends BaseAssignments {
 };
 
-// node_modules/@stainless-api/github-internal/resources/classrooms.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/classrooms.mjs
 var BaseClassrooms = /* @__PURE__ */ (() => {
   class BaseClassrooms2 extends APIResource {
     /**
@@ -11266,7 +11298,7 @@ var BaseClassrooms = /* @__PURE__ */ (() => {
 var Classrooms = class extends BaseClassrooms {
 };
 
-// node_modules/@stainless-api/github-internal/resources/codes-of-conduct.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/codes-of-conduct.mjs
 var BaseCodesOfConduct = /* @__PURE__ */ (() => {
   class BaseCodesOfConduct2 extends APIResource {
     /**
@@ -11288,7 +11320,7 @@ var BaseCodesOfConduct = /* @__PURE__ */ (() => {
 var CodesOfConduct = class extends BaseCodesOfConduct {
 };
 
-// node_modules/@stainless-api/github-internal/resources/emojis.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/emojis.mjs
 var BaseEmojis = /* @__PURE__ */ (() => {
   class BaseEmojis2 extends APIResource {
     /**
@@ -11304,7 +11336,7 @@ var BaseEmojis = /* @__PURE__ */ (() => {
 var Emojis = class extends BaseEmojis {
 };
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/dependabot.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/dependabot.mjs
 var BaseDependabot = /* @__PURE__ */ (() => {
   class BaseDependabot4 extends APIResource {
     /**
@@ -11342,7 +11374,7 @@ var BaseDependabot = /* @__PURE__ */ (() => {
 var Dependabot = class extends BaseDependabot {
 };
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/secret-scanning.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/secret-scanning.mjs
 var BaseSecretScanning = /* @__PURE__ */ (() => {
   class BaseSecretScanning4 extends APIResource {
     /**
@@ -11380,7 +11412,7 @@ var BaseSecretScanning = /* @__PURE__ */ (() => {
 var SecretScanning = class extends BaseSecretScanning {
 };
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/code-security/configurations/defaults.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/code-security/configurations/defaults.mjs
 var BaseDefaults = /* @__PURE__ */ (() => {
   class BaseDefaults3 extends APIResource {
     /**
@@ -11440,7 +11472,7 @@ var BaseDefaults = /* @__PURE__ */ (() => {
 var Defaults = class extends BaseDefaults {
 };
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/code-security/configurations/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/code-security/configurations/repositories.mjs
 var BaseRepositories = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -11473,7 +11505,7 @@ var BaseRepositories = /* @__PURE__ */ (() => {
 var Repositories = class extends BaseRepositories {
 };
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/code-security/configurations/configurations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/code-security/configurations/configurations.mjs
 var BaseConfigurations = /* @__PURE__ */ (() => {
   class BaseConfigurations3 extends APIResource {
     /**
@@ -11653,7 +11685,7 @@ var Configurations = /* @__PURE__ */ (() => {
   return Configurations3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/code-security/code-security.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/code-security/code-security.mjs
 var BaseCodeSecurity = /* @__PURE__ */ (() => {
   class BaseCodeSecurity3 extends APIResource {
   }
@@ -11675,7 +11707,7 @@ var CodeSecurity = /* @__PURE__ */ (() => {
   return CodeSecurity3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/enterprises.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/enterprises.mjs
 var BaseEnterprises = /* @__PURE__ */ (() => {
   class BaseEnterprises2 extends APIResource {
   }
@@ -11700,7 +11732,7 @@ var Enterprises = /* @__PURE__ */ (() => {
   return Enterprises2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/events.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/events.mjs
 var BaseEvents = /* @__PURE__ */ (() => {
   class BaseEvents4 extends APIResource {
     /**
@@ -11717,7 +11749,7 @@ var BaseEvents = /* @__PURE__ */ (() => {
 var Events = class extends BaseEvents {
 };
 
-// node_modules/@stainless-api/github-internal/resources/feeds.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/feeds.mjs
 var BaseFeeds = /* @__PURE__ */ (() => {
   class BaseFeeds2 extends APIResource {
     /**
@@ -11757,7 +11789,7 @@ var BaseFeeds = /* @__PURE__ */ (() => {
 var Feeds = class extends BaseFeeds {
 };
 
-// node_modules/@stainless-api/github-internal/resources/gists/comments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/gists/comments.mjs
 var BaseComments2 = /* @__PURE__ */ (() => {
   class BaseComments7 extends APIResource {
     /**
@@ -11885,7 +11917,7 @@ var BaseComments2 = /* @__PURE__ */ (() => {
 var Comments2 = class extends BaseComments2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/gists/forks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/gists/forks.mjs
 var BaseForks = /* @__PURE__ */ (() => {
   class BaseForks3 extends APIResource {
     /**
@@ -11925,7 +11957,7 @@ var BaseForks = /* @__PURE__ */ (() => {
 var Forks = class extends BaseForks {
 };
 
-// node_modules/@stainless-api/github-internal/resources/gists/star.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/gists/star.mjs
 var BaseStar = /* @__PURE__ */ (() => {
   class BaseStar2 extends APIResource {
     /**
@@ -11979,7 +12011,7 @@ var BaseStar = /* @__PURE__ */ (() => {
 var Star = class extends BaseStar {
 };
 
-// node_modules/@stainless-api/github-internal/resources/gists/gists.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/gists/gists.mjs
 var BaseGists = /* @__PURE__ */ (() => {
   class BaseGists2 extends APIResource {
     /**
@@ -12181,7 +12213,7 @@ var Gists = /* @__PURE__ */ (() => {
   return Gists2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/gitignore/templates.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/gitignore/templates.mjs
 var BaseTemplates = /* @__PURE__ */ (() => {
   class BaseTemplates2 extends APIResource {
     /**
@@ -12213,7 +12245,7 @@ var BaseTemplates = /* @__PURE__ */ (() => {
 var Templates = class extends BaseTemplates {
 };
 
-// node_modules/@stainless-api/github-internal/resources/gitignore/gitignore.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/gitignore/gitignore.mjs
 var BaseGitignore = /* @__PURE__ */ (() => {
   class BaseGitignore2 extends APIResource {
   }
@@ -12232,7 +12264,7 @@ var Gitignore = /* @__PURE__ */ (() => {
   return Gitignore2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/installation.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/installation.mjs
 var BaseInstallation = /* @__PURE__ */ (() => {
   class BaseInstallation2 extends APIResource {
     /**
@@ -12264,7 +12296,7 @@ var BaseInstallation = /* @__PURE__ */ (() => {
 var Installation = class extends BaseInstallation {
 };
 
-// node_modules/@stainless-api/github-internal/resources/issues.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/issues.mjs
 var BaseIssues = /* @__PURE__ */ (() => {
   class BaseIssues3 extends APIResource {
     /**
@@ -12306,7 +12338,7 @@ var BaseIssues = /* @__PURE__ */ (() => {
 var Issues = class extends BaseIssues {
 };
 
-// node_modules/@stainless-api/github-internal/resources/licenses.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/licenses.mjs
 var BaseLicenses = /* @__PURE__ */ (() => {
   class BaseLicenses2 extends APIResource {
     /**
@@ -12330,7 +12362,7 @@ var BaseLicenses = /* @__PURE__ */ (() => {
 var Licenses = class extends BaseLicenses {
 };
 
-// node_modules/@stainless-api/github-internal/resources/markdown.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/markdown.mjs
 var BaseMarkdown = /* @__PURE__ */ (() => {
   class BaseMarkdown2 extends APIResource {
     /**
@@ -12379,7 +12411,7 @@ var BaseMarkdown = /* @__PURE__ */ (() => {
 var Markdown = class extends BaseMarkdown {
 };
 
-// node_modules/@stainless-api/github-internal/resources/marketplace-listing/stubbed.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/marketplace-listing/stubbed.mjs
 var BaseStubbed = /* @__PURE__ */ (() => {
   class BaseStubbed2 extends APIResource {
     /**
@@ -12435,7 +12467,7 @@ var BaseStubbed = /* @__PURE__ */ (() => {
 var Stubbed = class extends BaseStubbed {
 };
 
-// node_modules/@stainless-api/github-internal/resources/marketplace-listing/marketplace-listing.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/marketplace-listing/marketplace-listing.mjs
 var BaseMarketplaceListing = /* @__PURE__ */ (() => {
   class BaseMarketplaceListing2 extends APIResource {
     /**
@@ -12502,7 +12534,7 @@ var MarketplaceListing = /* @__PURE__ */ (() => {
   return MarketplaceListing2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/meta.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/meta.mjs
 var BaseMeta = /* @__PURE__ */ (() => {
   class BaseMeta2 extends APIResource {
     /**
@@ -12529,7 +12561,7 @@ var BaseMeta = /* @__PURE__ */ (() => {
 var Meta = class extends BaseMeta {
 };
 
-// node_modules/@stainless-api/github-internal/resources/networks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/networks.mjs
 var BaseNetworks = /* @__PURE__ */ (() => {
   class BaseNetworks2 extends APIResource {
     /**
@@ -12547,7 +12579,7 @@ var BaseNetworks = /* @__PURE__ */ (() => {
 var Networks = class extends BaseNetworks {
 };
 
-// node_modules/@stainless-api/github-internal/resources/notifications/threads/subscription.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/notifications/threads/subscription.mjs
 var BaseSubscription = /* @__PURE__ */ (() => {
   class BaseSubscription3 extends APIResource {
     /**
@@ -12622,7 +12654,7 @@ var BaseSubscription = /* @__PURE__ */ (() => {
 var Subscription = class extends BaseSubscription {
 };
 
-// node_modules/@stainless-api/github-internal/resources/notifications/threads/threads.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/notifications/threads/threads.mjs
 var BaseThreads = /* @__PURE__ */ (() => {
   class BaseThreads2 extends APIResource {
     /**
@@ -12689,7 +12721,7 @@ var Threads = /* @__PURE__ */ (() => {
   return Threads2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/notifications/notifications.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/notifications/notifications.mjs
 var BaseNotifications = /* @__PURE__ */ (() => {
   class BaseNotifications3 extends APIResource {
     /**
@@ -12745,7 +12777,7 @@ var Notifications = /* @__PURE__ */ (() => {
   return Notifications3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/octocat.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/octocat.mjs
 var BaseOctocat = /* @__PURE__ */ (() => {
   class BaseOctocat2 extends APIResource {
     /**
@@ -12766,7 +12798,7 @@ var BaseOctocat = /* @__PURE__ */ (() => {
 var Octocat = class extends BaseOctocat {
 };
 
-// node_modules/@stainless-api/github-internal/resources/organizations/settings/billing.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/organizations/settings/billing.mjs
 var BaseBilling = /* @__PURE__ */ (() => {
   class BaseBilling5 extends APIResource {
     /**
@@ -12792,7 +12824,7 @@ var BaseBilling = /* @__PURE__ */ (() => {
 var Billing = class extends BaseBilling {
 };
 
-// node_modules/@stainless-api/github-internal/resources/organizations/settings/settings.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/organizations/settings/settings.mjs
 var BaseSettings = /* @__PURE__ */ (() => {
   class BaseSettings4 extends APIResource {
   }
@@ -12814,7 +12846,7 @@ var Settings = /* @__PURE__ */ (() => {
   return Settings4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/organizations/organizations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/organizations/organizations.mjs
 var BaseOrganizations = /* @__PURE__ */ (() => {
   class BaseOrganizations2 extends APIResource {
     /**
@@ -12843,7 +12875,7 @@ var Organizations = /* @__PURE__ */ (() => {
   return Organizations2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/blocks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/blocks.mjs
 var BaseBlocks = /* @__PURE__ */ (() => {
   class BaseBlocks3 extends APIResource {
     /**
@@ -12922,7 +12954,7 @@ var BaseBlocks = /* @__PURE__ */ (() => {
 var Blocks = class extends BaseBlocks {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/code-scanning.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/code-scanning.mjs
 var BaseCodeScanning = /* @__PURE__ */ (() => {
   class BaseCodeScanning3 extends APIResource {
     /**
@@ -12962,7 +12994,7 @@ var BaseCodeScanning = /* @__PURE__ */ (() => {
 var CodeScanning = class extends BaseCodeScanning {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/docker.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/docker.mjs
 var BaseDocker = /* @__PURE__ */ (() => {
   class BaseDocker3 extends APIResource {
     /**
@@ -12988,7 +13020,7 @@ var BaseDocker = /* @__PURE__ */ (() => {
 var Docker = class extends BaseDocker {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/interaction-limits.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/interaction-limits.mjs
 var BaseInteractionLimits = /* @__PURE__ */ (() => {
   class BaseInteractionLimits4 extends APIResource {
     /**
@@ -13053,7 +13085,7 @@ var BaseInteractionLimits = /* @__PURE__ */ (() => {
 var InteractionLimits = class extends BaseInteractionLimits {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/invitations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/invitations.mjs
 var BaseInvitations = /* @__PURE__ */ (() => {
   class BaseInvitations3 extends APIResource {
     /**
@@ -13151,7 +13183,7 @@ var BaseInvitations = /* @__PURE__ */ (() => {
 var Invitations = class extends BaseInvitations {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/memberships.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/memberships.mjs
 var BaseMemberships = /* @__PURE__ */ (() => {
   class BaseMemberships4 extends APIResource {
     /**
@@ -13243,7 +13275,7 @@ var BaseMemberships = /* @__PURE__ */ (() => {
 var Memberships = class extends BaseMemberships {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/outside-collaborators.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/outside-collaborators.mjs
 var BaseOutsideCollaborators = /* @__PURE__ */ (() => {
   class BaseOutsideCollaborators2 extends APIResource {
     /**
@@ -13313,7 +13345,7 @@ var BaseOutsideCollaborators = /* @__PURE__ */ (() => {
 var OutsideCollaborators = class extends BaseOutsideCollaborators {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/personal-access-token-requests.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/personal-access-token-requests.mjs
 var BasePersonalAccessTokenRequests = /* @__PURE__ */ (() => {
   class BasePersonalAccessTokenRequests2 extends APIResource {
     /**
@@ -13415,7 +13447,7 @@ var BasePersonalAccessTokenRequests = /* @__PURE__ */ (() => {
 var PersonalAccessTokenRequests = class extends BasePersonalAccessTokenRequests {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/personal-access-tokens.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/personal-access-tokens.mjs
 var BasePersonalAccessTokens = /* @__PURE__ */ (() => {
   class BasePersonalAccessTokens2 extends APIResource {
     /**
@@ -13509,7 +13541,7 @@ var BasePersonalAccessTokens = /* @__PURE__ */ (() => {
 var PersonalAccessTokens = class extends BasePersonalAccessTokens {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/private-registries.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/private-registries.mjs
 var BasePrivateRegistries = /* @__PURE__ */ (() => {
   class BasePrivateRegistries2 extends APIResource {
     /**
@@ -13648,7 +13680,7 @@ var BasePrivateRegistries = /* @__PURE__ */ (() => {
 var PrivateRegistries = class extends BasePrivateRegistries {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/public-members.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/public-members.mjs
 var BasePublicMembers = /* @__PURE__ */ (() => {
   class BasePublicMembers2 extends APIResource {
     /**
@@ -13738,7 +13770,7 @@ var BasePublicMembers = /* @__PURE__ */ (() => {
 var PublicMembers = class extends BasePublicMembers {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/secret-scanning.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/secret-scanning.mjs
 var BaseSecretScanning2 = /* @__PURE__ */ (() => {
   class BaseSecretScanning4 extends APIResource {
     /**
@@ -13775,7 +13807,7 @@ var BaseSecretScanning2 = /* @__PURE__ */ (() => {
 var SecretScanning2 = class extends BaseSecretScanning2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/cache.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/cache.mjs
 var BaseCache = /* @__PURE__ */ (() => {
   class BaseCache3 extends APIResource {
     /**
@@ -13825,7 +13857,7 @@ var BaseCache = /* @__PURE__ */ (() => {
 var Cache = class extends BaseCache {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/hosted-runners/images.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/hosted-runners/images.mjs
 var BaseImages = /* @__PURE__ */ (() => {
   class BaseImages2 extends APIResource {
     /**
@@ -13870,7 +13902,7 @@ var BaseImages = /* @__PURE__ */ (() => {
 var Images = class extends BaseImages {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/hosted-runners/hosted-runners.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/hosted-runners/hosted-runners.mjs
 var BaseHostedRunners = /* @__PURE__ */ (() => {
   class BaseHostedRunners2 extends APIResource {
     /**
@@ -14028,7 +14060,7 @@ var HostedRunners = /* @__PURE__ */ (() => {
   return HostedRunners2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/oidc/customization/sub.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/oidc/customization/sub.mjs
 var BaseSub = /* @__PURE__ */ (() => {
   class BaseSub3 extends APIResource {
     /**
@@ -14074,7 +14106,7 @@ var BaseSub = /* @__PURE__ */ (() => {
 var Sub = class extends BaseSub {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/oidc/customization/customization.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/oidc/customization/customization.mjs
 var BaseCustomization = /* @__PURE__ */ (() => {
   class BaseCustomization3 extends APIResource {
   }
@@ -14098,7 +14130,7 @@ var Customization = /* @__PURE__ */ (() => {
   return Customization3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/oidc/oidc.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/oidc/oidc.mjs
 var BaseOidc = /* @__PURE__ */ (() => {
   class BaseOidc3 extends APIResource {
   }
@@ -14121,7 +14153,7 @@ var Oidc = /* @__PURE__ */ (() => {
   return Oidc3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/repositories.mjs
 var BaseRepositories2 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -14232,7 +14264,7 @@ var BaseRepositories2 = /* @__PURE__ */ (() => {
 var Repositories2 = class extends BaseRepositories2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/selected-actions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/selected-actions.mjs
 var BaseSelectedActions = /* @__PURE__ */ (() => {
   class BaseSelectedActions3 extends APIResource {
     /**
@@ -14289,7 +14321,7 @@ var BaseSelectedActions = /* @__PURE__ */ (() => {
 var SelectedActions = class extends BaseSelectedActions {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/workflow.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/workflow.mjs
 var BaseWorkflow = /* @__PURE__ */ (() => {
   class BaseWorkflow3 extends APIResource {
     /**
@@ -14351,7 +14383,7 @@ var BaseWorkflow = /* @__PURE__ */ (() => {
 var Workflow = class extends BaseWorkflow {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/permissions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/permissions.mjs
 var BasePermissions = /* @__PURE__ */ (() => {
   class BasePermissions3 extends APIResource {
     /**
@@ -14418,7 +14450,7 @@ var Permissions = /* @__PURE__ */ (() => {
   return Permissions3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/runner-groups/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/runner-groups/repositories.mjs
 var BaseRepositories3 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -14516,7 +14548,7 @@ var BaseRepositories3 = /* @__PURE__ */ (() => {
 var Repositories3 = class extends BaseRepositories3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/runner-groups/runners.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/runner-groups/runners.mjs
 var BaseRunners = /* @__PURE__ */ (() => {
   class BaseRunners4 extends APIResource {
     /**
@@ -14615,7 +14647,7 @@ var BaseRunners = /* @__PURE__ */ (() => {
 var Runners = class extends BaseRunners {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/runner-groups/runner-groups.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/runner-groups/runner-groups.mjs
 var BaseRunnerGroups = /* @__PURE__ */ (() => {
   class BaseRunnerGroups2 extends APIResource {
     /**
@@ -14761,7 +14793,7 @@ var RunnerGroups = /* @__PURE__ */ (() => {
   return RunnerGroups2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/runners/labels.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/runners/labels.mjs
 var BaseLabels = /* @__PURE__ */ (() => {
   class BaseLabels5 extends APIResource {
     /**
@@ -14894,7 +14926,7 @@ var BaseLabels = /* @__PURE__ */ (() => {
 var Labels = class extends BaseLabels {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/runners/runners.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/runners/runners.mjs
 var BaseRunners2 = /* @__PURE__ */ (() => {
   class BaseRunners4 extends APIResource {
     /**
@@ -15089,7 +15121,7 @@ var Runners2 = /* @__PURE__ */ (() => {
   return Runners4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/secrets/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/secrets/repositories.mjs
 var BaseRepositories4 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -15211,7 +15243,7 @@ var BaseRepositories4 = /* @__PURE__ */ (() => {
 var Repositories4 = class extends BaseRepositories4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/secrets/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/secrets/secrets.mjs
 var BaseSecrets = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -15356,7 +15388,7 @@ var Secrets = /* @__PURE__ */ (() => {
   return Secrets9;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/variables/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/variables/repositories.mjs
 var BaseRepositories5 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -15477,7 +15509,7 @@ var BaseRepositories5 = /* @__PURE__ */ (() => {
 var Repositories5 = class extends BaseRepositories5 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/variables/variables.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/variables/variables.mjs
 var BaseVariables = /* @__PURE__ */ (() => {
   class BaseVariables4 extends APIResource {
     /**
@@ -15623,7 +15655,7 @@ var Variables = /* @__PURE__ */ (() => {
   return Variables4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/actions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/actions.mjs
 var BaseActions = /* @__PURE__ */ (() => {
   class BaseActions3 extends APIResource {
   }
@@ -15663,7 +15695,7 @@ var Actions = /* @__PURE__ */ (() => {
   return Actions3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/code-security/configurations/defaults.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/code-security/configurations/defaults.mjs
 var BaseDefaults2 = /* @__PURE__ */ (() => {
   class BaseDefaults3 extends APIResource {
     /**
@@ -15722,7 +15754,7 @@ var BaseDefaults2 = /* @__PURE__ */ (() => {
 var Defaults2 = class extends BaseDefaults2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/code-security/configurations/configurations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/code-security/configurations/configurations.mjs
 var BaseConfigurations2 = /* @__PURE__ */ (() => {
   class BaseConfigurations3 extends APIResource {
     /**
@@ -15949,7 +15981,7 @@ var Configurations2 = /* @__PURE__ */ (() => {
   return Configurations3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/code-security/code-security.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/code-security/code-security.mjs
 var BaseCodeSecurity2 = /* @__PURE__ */ (() => {
   class BaseCodeSecurity3 extends APIResource {
   }
@@ -15971,7 +16003,7 @@ var CodeSecurity2 = /* @__PURE__ */ (() => {
   return CodeSecurity3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/codespaces/secrets/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/codespaces/secrets/repositories.mjs
 var BaseRepositories6 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -16075,7 +16107,7 @@ var BaseRepositories6 = /* @__PURE__ */ (() => {
 var Repositories6 = class extends BaseRepositories6 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/codespaces/secrets/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/codespaces/secrets/secrets.mjs
 var BaseSecrets2 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -16198,7 +16230,7 @@ var Secrets2 = /* @__PURE__ */ (() => {
   return Secrets9;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/codespaces/codespaces.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/codespaces/codespaces.mjs
 var BaseCodespaces = /* @__PURE__ */ (() => {
   class BaseCodespaces5 extends APIResource {
     /**
@@ -16234,7 +16266,7 @@ var Codespaces = /* @__PURE__ */ (() => {
   return Codespaces5;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/copilot/billing/selected-teams.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/copilot/billing/selected-teams.mjs
 var BaseSelectedTeams = /* @__PURE__ */ (() => {
   class BaseSelectedTeams2 extends APIResource {
     /**
@@ -16317,7 +16349,7 @@ var BaseSelectedTeams = /* @__PURE__ */ (() => {
 var SelectedTeams = class extends BaseSelectedTeams {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/copilot/billing/selected-users.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/copilot/billing/selected-users.mjs
 var BaseSelectedUsers = /* @__PURE__ */ (() => {
   class BaseSelectedUsers2 extends APIResource {
     /**
@@ -16407,7 +16439,7 @@ var BaseSelectedUsers = /* @__PURE__ */ (() => {
 var SelectedUsers = class extends BaseSelectedUsers {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/copilot/billing/billing.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/copilot/billing/billing.mjs
 var BaseBilling2 = /* @__PURE__ */ (() => {
   class BaseBilling5 extends APIResource {
     /**
@@ -16482,7 +16514,7 @@ var Billing2 = /* @__PURE__ */ (() => {
   return Billing5;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/copilot/copilot.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/copilot/copilot.mjs
 var BaseCopilot = /* @__PURE__ */ (() => {
   class BaseCopilot3 extends APIResource {
     /**
@@ -16532,7 +16564,7 @@ var Copilot = /* @__PURE__ */ (() => {
   return Copilot3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/dependabot/secrets/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/dependabot/secrets/repositories.mjs
 var BaseRepositories7 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -16634,7 +16666,7 @@ var BaseRepositories7 = /* @__PURE__ */ (() => {
 var Repositories7 = class extends BaseRepositories7 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/dependabot/secrets/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/dependabot/secrets/secrets.mjs
 var BaseSecrets3 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -16758,7 +16790,7 @@ var Secrets3 = /* @__PURE__ */ (() => {
   return Secrets9;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/dependabot/dependabot.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/dependabot/dependabot.mjs
 var BaseDependabot2 = /* @__PURE__ */ (() => {
   class BaseDependabot4 extends APIResource {
     /**
@@ -16800,7 +16832,7 @@ var Dependabot2 = /* @__PURE__ */ (() => {
   return Dependabot4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/hooks/config.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/hooks/config.mjs
 var BaseConfig2 = /* @__PURE__ */ (() => {
   class BaseConfig4 extends APIResource {
     /**
@@ -16864,7 +16896,7 @@ var BaseConfig2 = /* @__PURE__ */ (() => {
 var Config2 = class extends BaseConfig2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/hooks/deliveries.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/hooks/deliveries.mjs
 var BaseDeliveries2 = /* @__PURE__ */ (() => {
   class BaseDeliveries4 extends APIResource {
     /**
@@ -16947,7 +16979,7 @@ var BaseDeliveries2 = /* @__PURE__ */ (() => {
 var Deliveries2 = class extends BaseDeliveries2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/hooks/hooks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/hooks/hooks.mjs
 var BaseHooks = /* @__PURE__ */ (() => {
   class BaseHooks3 extends APIResource {
     /**
@@ -17114,7 +17146,7 @@ var Hooks = /* @__PURE__ */ (() => {
   return Hooks3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/insights/api/summary-stats.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/insights/api/summary-stats.mjs
 var BaseSummaryStats = /* @__PURE__ */ (() => {
   class BaseSummaryStats2 extends APIResource {
     /**
@@ -17189,7 +17221,7 @@ var BaseSummaryStats = /* @__PURE__ */ (() => {
 var SummaryStats = class extends BaseSummaryStats {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/insights/api/time-stats.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/insights/api/time-stats.mjs
 var BaseTimeStats = /* @__PURE__ */ (() => {
   class BaseTimeStats2 extends APIResource {
     /**
@@ -17272,7 +17304,7 @@ var BaseTimeStats = /* @__PURE__ */ (() => {
 var TimeStats = class extends BaseTimeStats {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/insights/api/api.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/insights/api/api.mjs
 var BaseAPI = /* @__PURE__ */ (() => {
   class BaseAPI2 extends APIResource {
     /**
@@ -17351,7 +17383,7 @@ var API = /* @__PURE__ */ (() => {
   return API2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/insights/insights.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/insights/insights.mjs
 var BaseInsights = /* @__PURE__ */ (() => {
   class BaseInsights2 extends APIResource {
   }
@@ -17370,7 +17402,7 @@ var Insights = /* @__PURE__ */ (() => {
   return Insights2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/members/codespaces.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/members/codespaces.mjs
 var BaseCodespaces2 = /* @__PURE__ */ (() => {
   class BaseCodespaces5 extends APIResource {
     /**
@@ -17440,7 +17472,7 @@ var BaseCodespaces2 = /* @__PURE__ */ (() => {
 var Codespaces2 = class extends BaseCodespaces2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/members/members.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/members/members.mjs
 var BaseMembers = /* @__PURE__ */ (() => {
   class BaseMembers2 extends APIResource {
     /**
@@ -17550,7 +17582,7 @@ var Members = /* @__PURE__ */ (() => {
   return Members2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/migrations/archive.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/migrations/archive.mjs
 var BaseArchive = /* @__PURE__ */ (() => {
   class BaseArchive3 extends APIResource {
     /**
@@ -17599,7 +17631,7 @@ var BaseArchive = /* @__PURE__ */ (() => {
 var Archive = class extends BaseArchive {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/migrations/repos.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/migrations/repos.mjs
 var BaseRepos = /* @__PURE__ */ (() => {
   class BaseRepos6 extends APIResource {
     /**
@@ -17634,7 +17666,7 @@ var BaseRepos = /* @__PURE__ */ (() => {
 var Repos = class extends BaseRepos {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/migrations/migrations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/migrations/migrations.mjs
 var BaseMigrations = /* @__PURE__ */ (() => {
   class BaseMigrations3 extends APIResource {
     /**
@@ -17737,7 +17769,7 @@ var Migrations = /* @__PURE__ */ (() => {
   return Migrations3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/organization-roles/teams.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/organization-roles/teams.mjs
 var BaseTeams = /* @__PURE__ */ (() => {
   class BaseTeams5 extends APIResource {
     /**
@@ -17854,7 +17886,7 @@ var BaseTeams = /* @__PURE__ */ (() => {
 var Teams = class extends BaseTeams {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/organization-roles/users.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/organization-roles/users.mjs
 var BaseUsers = /* @__PURE__ */ (() => {
   class BaseUsers4 extends APIResource {
     /**
@@ -17971,7 +18003,7 @@ var BaseUsers = /* @__PURE__ */ (() => {
 var Users = class extends BaseUsers {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/organization-roles/organization-roles.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/organization-roles/organization-roles.mjs
 var BaseOrganizationRoles = /* @__PURE__ */ (() => {
   class BaseOrganizationRoles2 extends APIResource {
     /**
@@ -18045,7 +18077,7 @@ var OrganizationRoles = /* @__PURE__ */ (() => {
   return OrganizationRoles2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/packages/versions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/packages/versions.mjs
 var BaseVersions = /* @__PURE__ */ (() => {
   class BaseVersions4 extends APIResource {
     /**
@@ -18166,7 +18198,7 @@ var BaseVersions = /* @__PURE__ */ (() => {
 var Versions = class extends BaseVersions {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/packages/packages.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/packages/packages.mjs
 var BasePackages = /* @__PURE__ */ (() => {
   class BasePackages3 extends APIResource {
     /**
@@ -18296,7 +18328,7 @@ var Packages = /* @__PURE__ */ (() => {
   return Packages3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/properties/schema.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/properties/schema.mjs
 var BaseSchema = /* @__PURE__ */ (() => {
   class BaseSchema2 extends APIResource {
     /**
@@ -18439,7 +18471,7 @@ var BaseSchema = /* @__PURE__ */ (() => {
 var Schema = class extends BaseSchema {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/properties/values.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/properties/values.mjs
 var BaseValues = /* @__PURE__ */ (() => {
   class BaseValues3 extends APIResource {
     /**
@@ -18508,7 +18540,7 @@ var BaseValues = /* @__PURE__ */ (() => {
 var Values = class extends BaseValues {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/properties/properties.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/properties/properties.mjs
 var BaseProperties = /* @__PURE__ */ (() => {
   class BaseProperties3 extends APIResource {
   }
@@ -18533,7 +18565,7 @@ var Properties = /* @__PURE__ */ (() => {
   return Properties3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/rulesets/history.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/rulesets/history.mjs
 var BaseHistory = /* @__PURE__ */ (() => {
   class BaseHistory3 extends APIResource {
     /**
@@ -18580,7 +18612,7 @@ var BaseHistory = /* @__PURE__ */ (() => {
 var History = class extends BaseHistory {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/rulesets/rule-suites.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/rulesets/rule-suites.mjs
 var BaseRuleSuites = /* @__PURE__ */ (() => {
   class BaseRuleSuites3 extends APIResource {
     /**
@@ -18629,7 +18661,7 @@ var BaseRuleSuites = /* @__PURE__ */ (() => {
 var RuleSuites = class extends BaseRuleSuites {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/rulesets/rulesets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/rulesets/rulesets.mjs
 var BaseRulesets = /* @__PURE__ */ (() => {
   class BaseRulesets3 extends APIResource {
     /**
@@ -18757,7 +18789,7 @@ var Rulesets = /* @__PURE__ */ (() => {
   return Rulesets3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/settings/billing.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/settings/billing.mjs
 var BaseBilling3 = /* @__PURE__ */ (() => {
   class BaseBilling5 extends APIResource {
     /**
@@ -18834,7 +18866,7 @@ var BaseBilling3 = /* @__PURE__ */ (() => {
 var Billing3 = class extends BaseBilling3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/settings/network-configurations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/settings/network-configurations.mjs
 var BaseNetworkConfigurations = /* @__PURE__ */ (() => {
   class BaseNetworkConfigurations2 extends APIResource {
     /**
@@ -18954,7 +18986,7 @@ var BaseNetworkConfigurations = /* @__PURE__ */ (() => {
 var NetworkConfigurations = class extends BaseNetworkConfigurations {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/settings/settings.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/settings/settings.mjs
 var BaseSettings2 = /* @__PURE__ */ (() => {
   class BaseSettings4 extends APIResource {
     /**
@@ -18995,7 +19027,7 @@ var Settings2 = /* @__PURE__ */ (() => {
   return Settings4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/copilot.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/copilot.mjs
 var BaseCopilot2 = /* @__PURE__ */ (() => {
   class BaseCopilot3 extends APIResource {
     /**
@@ -19043,7 +19075,7 @@ var BaseCopilot2 = /* @__PURE__ */ (() => {
 var Copilot2 = class extends BaseCopilot2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/memberships.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/memberships.mjs
 var BaseMemberships2 = /* @__PURE__ */ (() => {
   class BaseMemberships4 extends APIResource {
     /**
@@ -19171,7 +19203,7 @@ var BaseMemberships2 = /* @__PURE__ */ (() => {
 var Memberships2 = class extends BaseMemberships2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/repos.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/repos.mjs
 var BaseRepos2 = /* @__PURE__ */ (() => {
   class BaseRepos6 extends APIResource {
     /**
@@ -19299,7 +19331,7 @@ var BaseRepos2 = /* @__PURE__ */ (() => {
 var Repos2 = class extends BaseRepos2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/reactions.mjs
 var BaseReactions2 = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -19390,7 +19422,7 @@ var BaseReactions2 = /* @__PURE__ */ (() => {
 var Reactions2 = class extends BaseReactions2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/comments/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/comments/reactions.mjs
 var BaseReactions3 = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -19488,7 +19520,7 @@ var BaseReactions3 = /* @__PURE__ */ (() => {
 var Reactions3 = class extends BaseReactions3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/comments/comments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/comments/comments.mjs
 var BaseComments3 = /* @__PURE__ */ (() => {
   class BaseComments7 extends APIResource {
     /**
@@ -19639,7 +19671,7 @@ var Comments3 = /* @__PURE__ */ (() => {
   return Comments7;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/discussions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/discussions.mjs
 var BaseDiscussions = /* @__PURE__ */ (() => {
   class BaseDiscussions2 extends APIResource {
     /**
@@ -19793,7 +19825,7 @@ var Discussions = /* @__PURE__ */ (() => {
   return Discussions2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/teams.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/teams.mjs
 var BaseTeams2 = /* @__PURE__ */ (() => {
   class BaseTeams5 extends APIResource {
     /**
@@ -19995,7 +20027,7 @@ var Teams2 = /* @__PURE__ */ (() => {
   return Teams5;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/orgs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/orgs.mjs
 var BaseOrgs = /* @__PURE__ */ (() => {
   class BaseOrgs3 extends APIResource {
     /**
@@ -20341,7 +20373,7 @@ var Orgs = /* @__PURE__ */ (() => {
   return Orgs4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/rate-limit.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/rate-limit.mjs
 var BaseRateLimitResource = /* @__PURE__ */ (() => {
   class BaseRateLimitResource2 extends APIResource {
     /**
@@ -20399,7 +20431,7 @@ var BaseRateLimitResource = /* @__PURE__ */ (() => {
 var RateLimitResource = class extends BaseRateLimitResource {
 };
 
-// node_modules/@stainless-api/github-internal/resources/search.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/search.mjs
 var BaseSearch = /* @__PURE__ */ (() => {
   class BaseSearch2 extends APIResource {
     /**
@@ -20574,7 +20606,7 @@ var BaseSearch = /* @__PURE__ */ (() => {
 var Search = class extends BaseSearch {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/assignees.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/assignees.mjs
 var BaseAssignees = /* @__PURE__ */ (() => {
   class BaseAssignees3 extends APIResource {
     /**
@@ -20629,7 +20661,7 @@ var BaseAssignees = /* @__PURE__ */ (() => {
 var Assignees = class extends BaseAssignees {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/attestations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/attestations.mjs
 var BaseAttestations = /* @__PURE__ */ (() => {
   class BaseAttestations2 extends APIResource {
     /**
@@ -20698,7 +20730,7 @@ var BaseAttestations = /* @__PURE__ */ (() => {
 var Attestations = class extends BaseAttestations {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/autolinks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/autolinks.mjs
 var BaseAutolinks = /* @__PURE__ */ (() => {
   class BaseAutolinks2 extends APIResource {
     /**
@@ -20785,7 +20817,7 @@ var BaseAutolinks = /* @__PURE__ */ (() => {
 var Autolinks = class extends BaseAutolinks {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/automated-security-fixes.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/automated-security-fixes.mjs
 var BaseAutomatedSecurityFixes = /* @__PURE__ */ (() => {
   class BaseAutomatedSecurityFixes2 extends APIResource {
     /**
@@ -20857,7 +20889,7 @@ var BaseAutomatedSecurityFixes = /* @__PURE__ */ (() => {
 var AutomatedSecurityFixes = class extends BaseAutomatedSecurityFixes {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/check-runs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/check-runs.mjs
 var BaseCheckRuns = /* @__PURE__ */ (() => {
   class BaseCheckRuns2 extends APIResource {
     /**
@@ -21017,7 +21049,7 @@ var BaseCheckRuns = /* @__PURE__ */ (() => {
 var CheckRuns = class extends BaseCheckRuns {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/check-suites.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/check-suites.mjs
 var BaseCheckSuites = /* @__PURE__ */ (() => {
   class BaseCheckSuites2 extends APIResource {
     /**
@@ -21147,7 +21179,7 @@ var BaseCheckSuites = /* @__PURE__ */ (() => {
 var CheckSuites = class extends BaseCheckSuites {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/codeowners.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/codeowners.mjs
 var BaseCodeowners = /* @__PURE__ */ (() => {
   class BaseCodeowners2 extends APIResource {
     /**
@@ -21180,7 +21212,7 @@ var BaseCodeowners = /* @__PURE__ */ (() => {
 var Codeowners = class extends BaseCodeowners {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/collaborators.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/collaborators.mjs
 var BaseCollaborators = /* @__PURE__ */ (() => {
   class BaseCollaborators2 extends APIResource {
     /**
@@ -21403,7 +21435,7 @@ var BaseCollaborators = /* @__PURE__ */ (() => {
 var Collaborators = class extends BaseCollaborators {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/community.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/community.mjs
 var BaseCommunity = /* @__PURE__ */ (() => {
   class BaseCommunity2 extends APIResource {
     /**
@@ -21443,7 +21475,7 @@ var BaseCommunity = /* @__PURE__ */ (() => {
 var Community = class extends BaseCommunity {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/contents.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/contents.mjs
 var BaseContents = /* @__PURE__ */ (() => {
   class BaseContents2 extends APIResource {
     /**
@@ -21595,7 +21627,7 @@ var BaseContents = /* @__PURE__ */ (() => {
 var Contents = class extends BaseContents {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/contributors.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/contributors.mjs
 var BaseContributors = /* @__PURE__ */ (() => {
   class BaseContributors2 extends APIResource {
     /**
@@ -21637,7 +21669,7 @@ var BaseContributors = /* @__PURE__ */ (() => {
 var Contributors = class extends BaseContributors {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/dependency-graph.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/dependency-graph.mjs
 var BaseDependencyGraph = /* @__PURE__ */ (() => {
   class BaseDependencyGraph2 extends APIResource {
     /**
@@ -21719,7 +21751,7 @@ var BaseDependencyGraph = /* @__PURE__ */ (() => {
 var DependencyGraph = class extends BaseDependencyGraph {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/forks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/forks.mjs
 var BaseForks2 = /* @__PURE__ */ (() => {
   class BaseForks3 extends APIResource {
     /**
@@ -21773,7 +21805,7 @@ var BaseForks2 = /* @__PURE__ */ (() => {
 var Forks2 = class extends BaseForks2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/interaction-limits.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/interaction-limits.mjs
 var BaseInteractionLimits2 = /* @__PURE__ */ (() => {
   class BaseInteractionLimits4 extends APIResource {
     /**
@@ -21848,7 +21880,7 @@ var BaseInteractionLimits2 = /* @__PURE__ */ (() => {
 var InteractionLimits2 = class extends BaseInteractionLimits2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/invitations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/invitations.mjs
 var BaseInvitations2 = /* @__PURE__ */ (() => {
   class BaseInvitations3 extends APIResource {
     /**
@@ -21915,7 +21947,7 @@ var BaseInvitations2 = /* @__PURE__ */ (() => {
 var Invitations2 = class extends BaseInvitations2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/keys.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/keys.mjs
 var BaseKeys = /* @__PURE__ */ (() => {
   class BaseKeys3 extends APIResource {
     /**
@@ -21998,7 +22030,7 @@ var BaseKeys = /* @__PURE__ */ (() => {
 var Keys = class extends BaseKeys {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/labels.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/labels.mjs
 var BaseLabels2 = /* @__PURE__ */ (() => {
   class BaseLabels5 extends APIResource {
     /**
@@ -22099,7 +22131,7 @@ var BaseLabels2 = /* @__PURE__ */ (() => {
 var Labels2 = class extends BaseLabels2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/languages.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/languages.mjs
 var BaseLanguages = /* @__PURE__ */ (() => {
   class BaseLanguages2 extends APIResource {
     /**
@@ -22128,7 +22160,7 @@ var BaseLanguages = /* @__PURE__ */ (() => {
 var Languages = class extends BaseLanguages {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/milestones.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/milestones.mjs
 var BaseMilestones = /* @__PURE__ */ (() => {
   class BaseMilestones2 extends APIResource {
     /**
@@ -22250,7 +22282,7 @@ var BaseMilestones = /* @__PURE__ */ (() => {
 var Milestones = class extends BaseMilestones {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/notifications.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/notifications.mjs
 var BaseNotifications2 = /* @__PURE__ */ (() => {
   class BaseNotifications3 extends APIResource {
     /**
@@ -22303,7 +22335,7 @@ var BaseNotifications2 = /* @__PURE__ */ (() => {
 var Notifications2 = class extends BaseNotifications2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/private-vulnerability-reporting.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/private-vulnerability-reporting.mjs
 var BasePrivateVulnerabilityReporting = /* @__PURE__ */ (() => {
   class BasePrivateVulnerabilityReporting2 extends APIResource {
     /**
@@ -22373,7 +22405,7 @@ var BasePrivateVulnerabilityReporting = /* @__PURE__ */ (() => {
 var PrivateVulnerabilityReporting = class extends BasePrivateVulnerabilityReporting {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/readme.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/readme.mjs
 var BaseReadme = /* @__PURE__ */ (() => {
   class BaseReadme2 extends APIResource {
     /**
@@ -22434,7 +22466,7 @@ var BaseReadme = /* @__PURE__ */ (() => {
 var Readme = class extends BaseReadme {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/rules.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/rules.mjs
 var BaseRules = /* @__PURE__ */ (() => {
   class BaseRules2 extends APIResource {
     /**
@@ -22463,7 +22495,7 @@ var BaseRules = /* @__PURE__ */ (() => {
 var Rules = class extends BaseRules {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/security-advisories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/security-advisories.mjs
 var BaseSecurityAdvisories = /* @__PURE__ */ (() => {
   class BaseSecurityAdvisories2 extends APIResource {
     /**
@@ -22676,7 +22708,7 @@ var BaseSecurityAdvisories = /* @__PURE__ */ (() => {
 var SecurityAdvisories = class extends BaseSecurityAdvisories {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/stats.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/stats.mjs
 var BaseStats = /* @__PURE__ */ (() => {
   class BaseStats2 extends APIResource {
     /**
@@ -22792,7 +22824,7 @@ var BaseStats = /* @__PURE__ */ (() => {
 var Stats = class extends BaseStats {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/subscription.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/subscription.mjs
 var BaseSubscription2 = /* @__PURE__ */ (() => {
   class BaseSubscription3 extends APIResource {
     /**
@@ -22861,7 +22893,7 @@ var BaseSubscription2 = /* @__PURE__ */ (() => {
 var Subscription2 = class extends BaseSubscription2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/tags.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/tags.mjs
 var BaseTags = /* @__PURE__ */ (() => {
   class BaseTags3 extends APIResource {
     /**
@@ -22892,7 +22924,7 @@ var BaseTags = /* @__PURE__ */ (() => {
 var Tags = class extends BaseTags {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/teams.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/teams.mjs
 var BaseTeams3 = /* @__PURE__ */ (() => {
   class BaseTeams5 extends APIResource {
     /**
@@ -22931,7 +22963,7 @@ var BaseTeams3 = /* @__PURE__ */ (() => {
 var Teams3 = class extends BaseTeams3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/topics.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/topics.mjs
 var BaseTopics = /* @__PURE__ */ (() => {
   class BaseTopics2 extends APIResource {
     /**
@@ -22972,7 +23004,7 @@ var BaseTopics = /* @__PURE__ */ (() => {
 var Topics = class extends BaseTopics {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/tory-invitations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/tory-invitations.mjs
 var BaseToryInvitations = /* @__PURE__ */ (() => {
   class BaseToryInvitations2 extends APIResource {
     /**
@@ -23031,7 +23063,7 @@ var BaseToryInvitations = /* @__PURE__ */ (() => {
 var ToryInvitations = class extends BaseToryInvitations {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/vulnerability-alerts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/vulnerability-alerts.mjs
 var BaseVulnerabilityAlerts = /* @__PURE__ */ (() => {
   class BaseVulnerabilityAlerts2 extends APIResource {
     /**
@@ -23107,7 +23139,7 @@ var BaseVulnerabilityAlerts = /* @__PURE__ */ (() => {
 var VulnerabilityAlerts = class extends BaseVulnerabilityAlerts {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/artifacts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/artifacts.mjs
 var BaseArtifacts = /* @__PURE__ */ (() => {
   class BaseArtifacts2 extends APIResource {
     /**
@@ -23203,7 +23235,7 @@ var BaseArtifacts = /* @__PURE__ */ (() => {
 var Artifacts = class extends BaseArtifacts {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/cache.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/cache.mjs
 var BaseCache2 = /* @__PURE__ */ (() => {
   class BaseCache3 extends APIResource {
     /**
@@ -23239,7 +23271,7 @@ var BaseCache2 = /* @__PURE__ */ (() => {
 var Cache2 = class extends BaseCache2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/caches.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/caches.mjs
 var BaseCaches = /* @__PURE__ */ (() => {
   class BaseCaches2 extends APIResource {
     /**
@@ -23317,7 +23349,7 @@ var BaseCaches = /* @__PURE__ */ (() => {
 var Caches = class extends BaseCaches {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/jobs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/jobs.mjs
 var BaseJobs = /* @__PURE__ */ (() => {
   class BaseJobs2 extends APIResource {
     /**
@@ -23394,7 +23426,7 @@ var BaseJobs = /* @__PURE__ */ (() => {
 var Jobs = class extends BaseJobs {
 };
 
-// node_modules/@stainless-api/github-internal/lib/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/lib/secrets.mjs
 var import_libsodium_wrappers = __toESM(require_libsodium_wrappers(), 1);
 async function encryptSecret(value, publicKey) {
   return import_libsodium_wrappers.default.ready.then(() => {
@@ -23406,7 +23438,7 @@ async function encryptSecret(value, publicKey) {
   });
 }
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/secrets.mjs
 var BaseSecrets4 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -23559,7 +23591,7 @@ var BaseSecrets4 = /* @__PURE__ */ (() => {
 var Secrets4 = class extends BaseSecrets4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/variables.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/variables.mjs
 var BaseVariables2 = /* @__PURE__ */ (() => {
   class BaseVariables4 extends APIResource {
     /**
@@ -23692,7 +23724,7 @@ var BaseVariables2 = /* @__PURE__ */ (() => {
 var Variables2 = class extends BaseVariables2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/workflows.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/workflows.mjs
 var BaseWorkflows = /* @__PURE__ */ (() => {
   class BaseWorkflows2 extends APIResource {
     /**
@@ -23897,7 +23929,7 @@ var BaseWorkflows = /* @__PURE__ */ (() => {
 var Workflows = class extends BaseWorkflows {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/oidc/customization/sub.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/oidc/customization/sub.mjs
 var BaseSub2 = /* @__PURE__ */ (() => {
   class BaseSub3 extends APIResource {
     /**
@@ -23951,7 +23983,7 @@ var BaseSub2 = /* @__PURE__ */ (() => {
 var Sub2 = class extends BaseSub2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/oidc/customization/customization.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/oidc/customization/customization.mjs
 var BaseCustomization2 = /* @__PURE__ */ (() => {
   class BaseCustomization3 extends APIResource {
   }
@@ -23975,7 +24007,7 @@ var Customization2 = /* @__PURE__ */ (() => {
   return Customization3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/oidc/oidc.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/oidc/oidc.mjs
 var BaseOidc2 = /* @__PURE__ */ (() => {
   class BaseOidc3 extends APIResource {
   }
@@ -23998,7 +24030,7 @@ var Oidc2 = /* @__PURE__ */ (() => {
   return Oidc3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/access.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/access.mjs
 var BaseAccess = /* @__PURE__ */ (() => {
   class BaseAccess2 extends APIResource {
     /**
@@ -24061,7 +24093,7 @@ var BaseAccess = /* @__PURE__ */ (() => {
 var Access = class extends BaseAccess {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/selected-actions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/selected-actions.mjs
 var BaseSelectedActions2 = /* @__PURE__ */ (() => {
   class BaseSelectedActions3 extends APIResource {
     /**
@@ -24119,7 +24151,7 @@ var BaseSelectedActions2 = /* @__PURE__ */ (() => {
 var SelectedActions2 = class extends BaseSelectedActions2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/workflow.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/workflow.mjs
 var BaseWorkflow2 = /* @__PURE__ */ (() => {
   class BaseWorkflow3 extends APIResource {
     /**
@@ -24183,7 +24215,7 @@ var BaseWorkflow2 = /* @__PURE__ */ (() => {
 var Workflow2 = class extends BaseWorkflow2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/permissions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/permissions.mjs
 var BasePermissions2 = /* @__PURE__ */ (() => {
   class BasePermissions3 extends APIResource {
     /**
@@ -24258,7 +24290,7 @@ var Permissions2 = /* @__PURE__ */ (() => {
   return Permissions3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/runners/labels.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/runners/labels.mjs
 var BaseLabels3 = /* @__PURE__ */ (() => {
   class BaseLabels5 extends APIResource {
     /**
@@ -24398,7 +24430,7 @@ var BaseLabels3 = /* @__PURE__ */ (() => {
 var Labels3 = class extends BaseLabels3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/runners/runners.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/runners/runners.mjs
 var BaseRunners3 = /* @__PURE__ */ (() => {
   class BaseRunners4 extends APIResource {
     /**
@@ -24601,7 +24633,7 @@ var Runners3 = /* @__PURE__ */ (() => {
   return Runners4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/runs/attempts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/runs/attempts.mjs
 var BaseAttempts = /* @__PURE__ */ (() => {
   class BaseAttempts2 extends APIResource {
     /**
@@ -24688,7 +24720,7 @@ var BaseAttempts = /* @__PURE__ */ (() => {
 var Attempts = class extends BaseAttempts {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/runs/logs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/runs/logs.mjs
 var BaseLogs = /* @__PURE__ */ (() => {
   class BaseLogs2 extends APIResource {
     /**
@@ -24749,7 +24781,7 @@ var BaseLogs = /* @__PURE__ */ (() => {
 var Logs = class extends BaseLogs {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/runs/pending-deployments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/runs/pending-deployments.mjs
 var BasePendingDeployments = /* @__PURE__ */ (() => {
   class BasePendingDeployments2 extends APIResource {
     /**
@@ -24818,7 +24850,7 @@ var BasePendingDeployments = /* @__PURE__ */ (() => {
 var PendingDeployments = class extends BasePendingDeployments {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/runs/runs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/runs/runs.mjs
 var BaseRuns = /* @__PURE__ */ (() => {
   class BaseRuns2 extends APIResource {
     /**
@@ -25148,7 +25180,7 @@ var Runs = /* @__PURE__ */ (() => {
   return Runs2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/actions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/actions.mjs
 var BaseActions2 = /* @__PURE__ */ (() => {
   class BaseActions3 extends APIResource {
     /**
@@ -25248,7 +25280,7 @@ var Actions2 = /* @__PURE__ */ (() => {
   return Actions3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/enforce-admins.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/enforce-admins.mjs
 var BaseEnforceAdmins = /* @__PURE__ */ (() => {
   class BaseEnforceAdmins2 extends APIResource {
     /**
@@ -25329,7 +25361,7 @@ var BaseEnforceAdmins = /* @__PURE__ */ (() => {
 var EnforceAdmins = class extends BaseEnforceAdmins {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-pull-request-reviews.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-pull-request-reviews.mjs
 var BaseRequiredPullRequestReviews = /* @__PURE__ */ (() => {
   class BaseRequiredPullRequestReviews2 extends APIResource {
     /**
@@ -25424,7 +25456,7 @@ var BaseRequiredPullRequestReviews = /* @__PURE__ */ (() => {
 var RequiredPullRequestReviews = class extends BaseRequiredPullRequestReviews {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-signatures.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-signatures.mjs
 var BaseRequiredSignatures = /* @__PURE__ */ (() => {
   class BaseRequiredSignatures2 extends APIResource {
     /**
@@ -25513,7 +25545,7 @@ var BaseRequiredSignatures = /* @__PURE__ */ (() => {
 var RequiredSignatures = class extends BaseRequiredSignatures {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-status-checks/contexts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-status-checks/contexts.mjs
 var BaseContexts = /* @__PURE__ */ (() => {
   class BaseContexts2 extends APIResource {
     /**
@@ -25622,7 +25654,7 @@ var BaseContexts = /* @__PURE__ */ (() => {
 var Contexts = class extends BaseContexts {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-status-checks/required-status-checks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-status-checks/required-status-checks.mjs
 var BaseRequiredStatusChecks = /* @__PURE__ */ (() => {
   class BaseRequiredStatusChecks2 extends APIResource {
     /**
@@ -25706,7 +25738,7 @@ var RequiredStatusChecks = /* @__PURE__ */ (() => {
   return RequiredStatusChecks2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/apps.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/apps.mjs
 var BaseApps2 = /* @__PURE__ */ (() => {
   class BaseApps3 extends APIResource {
     /**
@@ -25824,7 +25856,7 @@ var BaseApps2 = /* @__PURE__ */ (() => {
 var Apps2 = class extends BaseApps2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/teams.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/teams.mjs
 var BaseTeams4 = /* @__PURE__ */ (() => {
   class BaseTeams5 extends APIResource {
     /**
@@ -25945,7 +25977,7 @@ var BaseTeams4 = /* @__PURE__ */ (() => {
 var Teams4 = class extends BaseTeams4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/users.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/users.mjs
 var BaseUsers2 = /* @__PURE__ */ (() => {
   class BaseUsers4 extends APIResource {
     /**
@@ -26067,7 +26099,7 @@ var BaseUsers2 = /* @__PURE__ */ (() => {
 var Users2 = class extends BaseUsers2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/restrictions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/restrictions.mjs
 var BaseRestrictions = /* @__PURE__ */ (() => {
   class BaseRestrictions2 extends APIResource {
     /**
@@ -26143,7 +26175,7 @@ var Restrictions = /* @__PURE__ */ (() => {
   return Restrictions2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/protection.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/protection.mjs
 var BaseProtection = /* @__PURE__ */ (() => {
   class BaseProtection2 extends APIResource {
     /**
@@ -26273,7 +26305,7 @@ var Protection = /* @__PURE__ */ (() => {
   return Protection2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/branches.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/branches.mjs
 var BaseBranches = /* @__PURE__ */ (() => {
   class BaseBranches2 extends APIResource {
     /**
@@ -26362,7 +26394,7 @@ var Branches = /* @__PURE__ */ (() => {
   return Branches3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/analyses.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/analyses.mjs
 var BaseAnalyses = /* @__PURE__ */ (() => {
   class BaseAnalyses2 extends APIResource {
     /**
@@ -26537,7 +26569,7 @@ var BaseAnalyses = /* @__PURE__ */ (() => {
 var Analyses = class extends BaseAnalyses {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/default-setup.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/default-setup.mjs
 var BaseDefaultSetup = /* @__PURE__ */ (() => {
   class BaseDefaultSetup2 extends APIResource {
     /**
@@ -26596,7 +26628,7 @@ var BaseDefaultSetup = /* @__PURE__ */ (() => {
 var DefaultSetup = class extends BaseDefaultSetup {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/sarifs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/sarifs.mjs
 var BaseSarifs = /* @__PURE__ */ (() => {
   class BaseSarifs2 extends APIResource {
     /**
@@ -26706,7 +26738,7 @@ var BaseSarifs = /* @__PURE__ */ (() => {
 var Sarifs = class extends BaseSarifs {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/alerts/autofix.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/alerts/autofix.mjs
 var BaseAutofix = /* @__PURE__ */ (() => {
   class BaseAutofix2 extends APIResource {
     /**
@@ -26792,7 +26824,7 @@ var BaseAutofix = /* @__PURE__ */ (() => {
 var Autofix = class extends BaseAutofix {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/alerts/instances.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/alerts/instances.mjs
 var BaseInstances = /* @__PURE__ */ (() => {
   class BaseInstances2 extends APIResource {
     /**
@@ -26829,7 +26861,7 @@ var BaseInstances = /* @__PURE__ */ (() => {
 var Instances = class extends BaseInstances {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/alerts/alerts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/alerts/alerts.mjs
 var BaseAlerts = /* @__PURE__ */ (() => {
   class BaseAlerts4 extends APIResource {
     /**
@@ -26929,7 +26961,7 @@ var Alerts = /* @__PURE__ */ (() => {
   return Alerts4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/codeql/databases.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/codeql/databases.mjs
 var BaseDatabases = /* @__PURE__ */ (() => {
   class BaseDatabases2 extends APIResource {
     /**
@@ -27013,7 +27045,7 @@ var BaseDatabases = /* @__PURE__ */ (() => {
 var Databases = class extends BaseDatabases {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/codeql/variant-analyses.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/codeql/variant-analyses.mjs
 var BaseVariantAnalyses = /* @__PURE__ */ (() => {
   class BaseVariantAnalyses2 extends APIResource {
     /**
@@ -27106,7 +27138,7 @@ var BaseVariantAnalyses = /* @__PURE__ */ (() => {
 var VariantAnalyses = class extends BaseVariantAnalyses {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/codeql/codeql.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/codeql/codeql.mjs
 var BaseCodeql = /* @__PURE__ */ (() => {
   class BaseCodeql2 extends APIResource {
   }
@@ -27132,7 +27164,7 @@ var Codeql = /* @__PURE__ */ (() => {
   return Codeql2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/code-scanning.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/code-scanning.mjs
 var BaseCodeScanning2 = /* @__PURE__ */ (() => {
   class BaseCodeScanning3 extends APIResource {
   }
@@ -27166,7 +27198,7 @@ var CodeScanning2 = /* @__PURE__ */ (() => {
   return CodeScanning3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/codespaces/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/codespaces/secrets.mjs
 var BaseSecrets5 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -27291,7 +27323,7 @@ var BaseSecrets5 = /* @__PURE__ */ (() => {
 var Secrets5 = class extends BaseSecrets5 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/codespaces/codespaces.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/codespaces/codespaces.mjs
 var BaseCodespaces3 = /* @__PURE__ */ (() => {
   class BaseCodespaces5 extends APIResource {
     /**
@@ -27437,7 +27469,7 @@ var Codespaces3 = /* @__PURE__ */ (() => {
   return Codespaces5;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/comments/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/comments/reactions.mjs
 var BaseReactions4 = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -27516,7 +27548,7 @@ var BaseReactions4 = /* @__PURE__ */ (() => {
 var Reactions4 = class extends BaseReactions4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/comments/comments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/comments/comments.mjs
 var BaseComments4 = /* @__PURE__ */ (() => {
   class BaseComments7 extends APIResource {
     /**
@@ -27650,7 +27682,7 @@ var Comments4 = /* @__PURE__ */ (() => {
   return Comments7;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/commits/comments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/commits/comments.mjs
 var BaseComments5 = /* @__PURE__ */ (() => {
   class BaseComments7 extends APIResource {
     /**
@@ -27745,7 +27777,7 @@ var BaseComments5 = /* @__PURE__ */ (() => {
 var Comments5 = class extends BaseComments5 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/commits/commits.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/commits/commits.mjs
 var BaseCommits = /* @__PURE__ */ (() => {
   class BaseCommits3 extends APIResource {
     /**
@@ -28032,7 +28064,7 @@ var Commits = /* @__PURE__ */ (() => {
   return Commits3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/dependabot/alerts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/dependabot/alerts.mjs
 var BaseAlerts2 = /* @__PURE__ */ (() => {
   class BaseAlerts4 extends APIResource {
     /**
@@ -28111,7 +28143,7 @@ var BaseAlerts2 = /* @__PURE__ */ (() => {
 var Alerts2 = class extends BaseAlerts2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/dependabot/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/dependabot/secrets.mjs
 var BaseSecrets6 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -28236,7 +28268,7 @@ var BaseSecrets6 = /* @__PURE__ */ (() => {
 var Secrets6 = class extends BaseSecrets6 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/dependabot/dependabot.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/dependabot/dependabot.mjs
 var BaseDependabot3 = /* @__PURE__ */ (() => {
   class BaseDependabot4 extends APIResource {
   }
@@ -28261,7 +28293,7 @@ var Dependabot3 = /* @__PURE__ */ (() => {
   return Dependabot4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/deployments/statuses.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/deployments/statuses.mjs
 var BaseStatuses = /* @__PURE__ */ (() => {
   class BaseStatuses2 extends APIResource {
     /**
@@ -28336,7 +28368,7 @@ var BaseStatuses = /* @__PURE__ */ (() => {
 var Statuses = class extends BaseStatuses {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/deployments/deployments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/deployments/deployments.mjs
 var BaseDeployments = /* @__PURE__ */ (() => {
   class BaseDeployments3 extends APIResource {
     /**
@@ -28503,7 +28535,7 @@ var Deployments = /* @__PURE__ */ (() => {
   return Deployments3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/environments/deployment-branch-policies.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/environments/deployment-branch-policies.mjs
 var BaseDeploymentBranchPolicies = /* @__PURE__ */ (() => {
   class BaseDeploymentBranchPolicies2 extends APIResource {
     /**
@@ -28624,7 +28656,7 @@ var BaseDeploymentBranchPolicies = /* @__PURE__ */ (() => {
 var DeploymentBranchPolicies = class extends BaseDeploymentBranchPolicies {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/environments/deployment-protection-rules.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/environments/deployment-protection-rules.mjs
 var BaseDeploymentProtectionRules = /* @__PURE__ */ (() => {
   class BaseDeploymentProtectionRules2 extends APIResource {
     /**
@@ -28772,7 +28804,7 @@ var BaseDeploymentProtectionRules = /* @__PURE__ */ (() => {
 var DeploymentProtectionRules = class extends BaseDeploymentProtectionRules {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/environments/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/environments/secrets.mjs
 var BaseSecrets7 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -28917,7 +28949,7 @@ var BaseSecrets7 = /* @__PURE__ */ (() => {
 var Secrets7 = class extends BaseSecrets7 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/environments/variables.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/environments/variables.mjs
 var BaseVariables3 = /* @__PURE__ */ (() => {
   class BaseVariables4 extends APIResource {
     /**
@@ -29060,7 +29092,7 @@ var BaseVariables3 = /* @__PURE__ */ (() => {
 var Variables3 = class extends BaseVariables3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/environments/environments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/environments/environments.mjs
 var BaseEnvironments = /* @__PURE__ */ (() => {
   class BaseEnvironments2 extends APIResource {
     /**
@@ -29196,7 +29228,7 @@ var Environments = /* @__PURE__ */ (() => {
   return Environments2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/git-refs/blobs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/git-refs/blobs.mjs
 var BaseBlobs = /* @__PURE__ */ (() => {
   class BaseBlobs2 extends APIResource {
     /**
@@ -29253,7 +29285,7 @@ var BaseBlobs = /* @__PURE__ */ (() => {
 var Blobs = class extends BaseBlobs {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/git-refs/commits.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/git-refs/commits.mjs
 var BaseCommits2 = /* @__PURE__ */ (() => {
   class BaseCommits3 extends APIResource {
     /**
@@ -29376,7 +29408,7 @@ var BaseCommits2 = /* @__PURE__ */ (() => {
 var Commits2 = class extends BaseCommits2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/git-refs/tags.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/git-refs/tags.mjs
 var BaseTags2 = /* @__PURE__ */ (() => {
   class BaseTags3 extends APIResource {
     /**
@@ -29497,7 +29529,7 @@ var BaseTags2 = /* @__PURE__ */ (() => {
 var Tags2 = class extends BaseTags2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/git-refs/trees.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/git-refs/trees.mjs
 var BaseTrees = /* @__PURE__ */ (() => {
   class BaseTrees2 extends APIResource {
     /**
@@ -29568,7 +29600,7 @@ var BaseTrees = /* @__PURE__ */ (() => {
 var Trees = class extends BaseTrees {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/git-refs/git-refs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/git-refs/git-refs.mjs
 var BaseGitRefs = /* @__PURE__ */ (() => {
   class BaseGitRefs2 extends APIResource {
     /**
@@ -29712,7 +29744,7 @@ var GitRefs = /* @__PURE__ */ (() => {
   return GitRefs2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/hooks/config.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/hooks/config.mjs
 var BaseConfig3 = /* @__PURE__ */ (() => {
   class BaseConfig4 extends APIResource {
     /**
@@ -29770,7 +29802,7 @@ var BaseConfig3 = /* @__PURE__ */ (() => {
 var Config3 = class extends BaseConfig3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/hooks/deliveries.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/hooks/deliveries.mjs
 var BaseDeliveries3 = /* @__PURE__ */ (() => {
   class BaseDeliveries4 extends APIResource {
     /**
@@ -29836,7 +29868,7 @@ var BaseDeliveries3 = /* @__PURE__ */ (() => {
 var Deliveries3 = class extends BaseDeliveries3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/hooks/hooks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/hooks/hooks.mjs
 var BaseHooks2 = /* @__PURE__ */ (() => {
   class BaseHooks3 extends APIResource {
     /**
@@ -30003,7 +30035,7 @@ var Hooks2 = /* @__PURE__ */ (() => {
   return Hooks3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/assignees.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/assignees.mjs
 var BaseAssignees2 = /* @__PURE__ */ (() => {
   class BaseAssignees3 extends APIResource {
     /**
@@ -30083,7 +30115,7 @@ var BaseAssignees2 = /* @__PURE__ */ (() => {
 var Assignees2 = class extends BaseAssignees2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/events.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/events.mjs
 var BaseEvents2 = /* @__PURE__ */ (() => {
   class BaseEvents4 extends APIResource {
     /**
@@ -30130,7 +30162,7 @@ var BaseEvents2 = /* @__PURE__ */ (() => {
 var Events2 = class extends BaseEvents2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/labels.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/labels.mjs
 var BaseLabels4 = /* @__PURE__ */ (() => {
   class BaseLabels5 extends APIResource {
     /**
@@ -30233,7 +30265,7 @@ var BaseLabels4 = /* @__PURE__ */ (() => {
 var Labels4 = class extends BaseLabels4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/lock.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/lock.mjs
 var BaseLock = /* @__PURE__ */ (() => {
   class BaseLock2 extends APIResource {
     /**
@@ -30290,7 +30322,7 @@ var BaseLock = /* @__PURE__ */ (() => {
 var Lock = class extends BaseLock {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/reactions.mjs
 var BaseReactions5 = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -30367,7 +30399,7 @@ var BaseReactions5 = /* @__PURE__ */ (() => {
 var Reactions5 = class extends BaseReactions5 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/sub-issues.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/sub-issues.mjs
 var BaseSubIssues = /* @__PURE__ */ (() => {
   class BaseSubIssues2 extends APIResource {
     /**
@@ -30474,7 +30506,7 @@ var BaseSubIssues = /* @__PURE__ */ (() => {
 var SubIssues = class extends BaseSubIssues {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/timeline.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/timeline.mjs
 var BaseTimeline = /* @__PURE__ */ (() => {
   class BaseTimeline2 extends APIResource {
     /**
@@ -30506,7 +30538,7 @@ var BaseTimeline = /* @__PURE__ */ (() => {
 var Timeline = class extends BaseTimeline {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/issues.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/issues.mjs
 var BaseIssues2 = /* @__PURE__ */ (() => {
   class BaseIssues3 extends APIResource {
     /**
@@ -30805,7 +30837,7 @@ var Issues2 = /* @__PURE__ */ (() => {
   return Issues3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/pages/builds.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pages/builds.mjs
 var BaseBuilds = /* @__PURE__ */ (() => {
   class BaseBuilds2 extends APIResource {
     /**
@@ -30897,7 +30929,7 @@ var BaseBuilds = /* @__PURE__ */ (() => {
 var Builds = class extends BaseBuilds {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/pages/deployments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pages/deployments.mjs
 var BaseDeployments2 = /* @__PURE__ */ (() => {
   class BaseDeployments3 extends APIResource {
     /**
@@ -30973,7 +31005,7 @@ var BaseDeployments2 = /* @__PURE__ */ (() => {
 var Deployments2 = class extends BaseDeployments2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/pages/pages.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pages/pages.mjs
 var BasePages = /* @__PURE__ */ (() => {
   class BasePages2 extends APIResource {
     /**
@@ -31116,7 +31148,7 @@ var Pages = /* @__PURE__ */ (() => {
   return Pages2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/properties/values.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/properties/values.mjs
 var BaseValues2 = /* @__PURE__ */ (() => {
   class BaseValues3 extends APIResource {
     /**
@@ -31176,7 +31208,7 @@ var BaseValues2 = /* @__PURE__ */ (() => {
 var Values2 = class extends BaseValues2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/properties/properties.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/properties/properties.mjs
 var BaseProperties2 = /* @__PURE__ */ (() => {
   class BaseProperties3 extends APIResource {
   }
@@ -31198,7 +31230,7 @@ var Properties2 = /* @__PURE__ */ (() => {
   return Properties3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/pulls/merge.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pulls/merge.mjs
 var BaseMerge = /* @__PURE__ */ (() => {
   class BaseMerge2 extends APIResource {
     /**
@@ -31256,7 +31288,7 @@ var BaseMerge = /* @__PURE__ */ (() => {
 var Merge = class extends BaseMerge {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/pulls/requested-reviewers.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pulls/requested-reviewers.mjs
 var BaseRequestedReviewers = /* @__PURE__ */ (() => {
   class BaseRequestedReviewers2 extends APIResource {
     /**
@@ -31340,7 +31372,7 @@ var BaseRequestedReviewers = /* @__PURE__ */ (() => {
 var RequestedReviewers = class extends BaseRequestedReviewers {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/pulls/reviews.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pulls/reviews.mjs
 var BaseReviews = /* @__PURE__ */ (() => {
   class BaseReviews2 extends APIResource {
     /**
@@ -31667,7 +31699,7 @@ var BaseReviews = /* @__PURE__ */ (() => {
 var Reviews = class extends BaseReviews {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/pulls/comments/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pulls/comments/reactions.mjs
 var BaseReactions6 = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -31744,7 +31776,7 @@ var BaseReactions6 = /* @__PURE__ */ (() => {
 var Reactions6 = class extends BaseReactions6 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/pulls/comments/comments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pulls/comments/comments.mjs
 var BaseComments6 = /* @__PURE__ */ (() => {
   class BaseComments7 extends APIResource {
     /**
@@ -31931,7 +31963,7 @@ var Comments6 = /* @__PURE__ */ (() => {
   return Comments7;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/pulls/pulls.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pulls/pulls.mjs
 var BasePulls = /* @__PURE__ */ (() => {
   class BasePulls2 extends APIResource {
     /**
@@ -32378,7 +32410,7 @@ var Pulls = /* @__PURE__ */ (() => {
   return Pulls2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/releases/assets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/releases/assets.mjs
 var BaseAssets = /* @__PURE__ */ (() => {
   class BaseAssets2 extends APIResource {
     /**
@@ -32469,7 +32501,7 @@ var BaseAssets = /* @__PURE__ */ (() => {
 var Assets = class extends BaseAssets {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/releases/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/releases/reactions.mjs
 var BaseReactions7 = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -32548,7 +32580,7 @@ var BaseReactions7 = /* @__PURE__ */ (() => {
 var Reactions7 = class extends BaseReactions7 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/releases/releases.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/releases/releases.mjs
 var BaseReleases = /* @__PURE__ */ (() => {
   class BaseReleases2 extends APIResource {
     /**
@@ -32738,7 +32770,7 @@ var Releases = /* @__PURE__ */ (() => {
   return Releases2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/rulesets/history.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/rulesets/history.mjs
 var BaseHistory2 = /* @__PURE__ */ (() => {
   class BaseHistory3 extends APIResource {
     /**
@@ -32788,7 +32820,7 @@ var BaseHistory2 = /* @__PURE__ */ (() => {
 var History2 = class extends BaseHistory2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/rulesets/rule-suites.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/rulesets/rule-suites.mjs
 var BaseRuleSuites2 = /* @__PURE__ */ (() => {
   class BaseRuleSuites3 extends APIResource {
     /**
@@ -32839,7 +32871,7 @@ var BaseRuleSuites2 = /* @__PURE__ */ (() => {
 var RuleSuites2 = class extends BaseRuleSuites2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/rulesets/rulesets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/rulesets/rulesets.mjs
 var BaseRulesets2 = /* @__PURE__ */ (() => {
   class BaseRulesets3 extends APIResource {
     /**
@@ -32998,7 +33030,7 @@ var Rulesets2 = /* @__PURE__ */ (() => {
   return Rulesets3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/secret-scanning/alerts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/secret-scanning/alerts.mjs
 var BaseAlerts3 = /* @__PURE__ */ (() => {
   class BaseAlerts4 extends APIResource {
     /**
@@ -33116,7 +33148,7 @@ var BaseAlerts3 = /* @__PURE__ */ (() => {
 var Alerts3 = class extends BaseAlerts3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/secret-scanning/secret-scanning.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/secret-scanning/secret-scanning.mjs
 var BaseSecretScanning3 = /* @__PURE__ */ (() => {
   class BaseSecretScanning4 extends APIResource {
     /**
@@ -33187,7 +33219,7 @@ var SecretScanning3 = /* @__PURE__ */ (() => {
   return SecretScanning4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/traffic/popular.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/traffic/popular.mjs
 var BasePopular = /* @__PURE__ */ (() => {
   class BasePopular2 extends APIResource {
     /**
@@ -33233,7 +33265,7 @@ var BasePopular = /* @__PURE__ */ (() => {
 var Popular = class extends BasePopular {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/traffic/traffic.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/traffic/traffic.mjs
 var BaseTraffic = /* @__PURE__ */ (() => {
   class BaseTraffic2 extends APIResource {
     /**
@@ -33286,7 +33318,7 @@ var Traffic = /* @__PURE__ */ (() => {
   return Traffic2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/repos.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/repos.mjs
 var BaseRepos3 = /* @__PURE__ */ (() => {
   class BaseRepos6 extends APIResource {
     constructor() {
@@ -34183,7 +34215,7 @@ var Repos3 = /* @__PURE__ */ (() => {
   return Repos6;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/blocks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/blocks.mjs
 var BaseBlocks2 = /* @__PURE__ */ (() => {
   class BaseBlocks3 extends APIResource {
     /**
@@ -34252,7 +34284,7 @@ var BaseBlocks2 = /* @__PURE__ */ (() => {
 var Blocks2 = class extends BaseBlocks2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/docker.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/docker.mjs
 var BaseDocker2 = /* @__PURE__ */ (() => {
   class BaseDocker3 extends APIResource {
     /**
@@ -34295,7 +34327,7 @@ var BaseDocker2 = /* @__PURE__ */ (() => {
 var Docker2 = class extends BaseDocker2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/emails.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/emails.mjs
 var BaseEmails = /* @__PURE__ */ (() => {
   class BaseEmails2 extends APIResource {
     /**
@@ -34372,7 +34404,7 @@ var BaseEmails = /* @__PURE__ */ (() => {
 var Emails = class extends BaseEmails {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/events.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/events.mjs
 var BaseEvents3 = /* @__PURE__ */ (() => {
   class BaseEvents4 extends APIResource {
     /**
@@ -34446,7 +34478,7 @@ var BaseEvents3 = /* @__PURE__ */ (() => {
 var Events3 = class extends BaseEvents3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/following.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/following.mjs
 var BaseFollowing = /* @__PURE__ */ (() => {
   class BaseFollowing2 extends APIResource {
     /**
@@ -34495,7 +34527,7 @@ var BaseFollowing = /* @__PURE__ */ (() => {
 var Following = class extends BaseFollowing {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/gpg-keys.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/gpg-keys.mjs
 var BaseGpgKeys = /* @__PURE__ */ (() => {
   class BaseGpgKeys2 extends APIResource {
     /**
@@ -34571,7 +34603,7 @@ var BaseGpgKeys = /* @__PURE__ */ (() => {
 var GpgKeys = class extends BaseGpgKeys {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/interaction-limits.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/interaction-limits.mjs
 var BaseInteractionLimits3 = /* @__PURE__ */ (() => {
   class BaseInteractionLimits4 extends APIResource {
     /**
@@ -34627,7 +34659,7 @@ var BaseInteractionLimits3 = /* @__PURE__ */ (() => {
 var InteractionLimits3 = class extends BaseInteractionLimits3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/keys.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/keys.mjs
 var BaseKeys2 = /* @__PURE__ */ (() => {
   class BaseKeys3 extends APIResource {
     /**
@@ -34702,7 +34734,7 @@ var BaseKeys2 = /* @__PURE__ */ (() => {
 var Keys2 = class extends BaseKeys2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/marketplace-purchases.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/marketplace-purchases.mjs
 var BaseMarketplacePurchases = /* @__PURE__ */ (() => {
   class BaseMarketplacePurchases2 extends APIResource {
     /**
@@ -34743,7 +34775,7 @@ var BaseMarketplacePurchases = /* @__PURE__ */ (() => {
 var MarketplacePurchases = class extends BaseMarketplacePurchases {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/received-events.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/received-events.mjs
 var BaseReceivedEvents = /* @__PURE__ */ (() => {
   class BaseReceivedEvents2 extends APIResource {
     /**
@@ -34794,7 +34826,7 @@ var BaseReceivedEvents = /* @__PURE__ */ (() => {
 var ReceivedEvents = class extends BaseReceivedEvents {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/repos.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/repos.mjs
 var BaseRepos4 = /* @__PURE__ */ (() => {
   class BaseRepos6 extends APIResource {
     /**
@@ -35094,7 +35126,7 @@ var BaseRepos4 = /* @__PURE__ */ (() => {
 var Repos4 = class extends BaseRepos4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/social-accounts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/social-accounts.mjs
 var BaseSocialAccounts = /* @__PURE__ */ (() => {
   class BaseSocialAccounts2 extends APIResource {
     /**
@@ -35166,7 +35198,7 @@ var BaseSocialAccounts = /* @__PURE__ */ (() => {
 var SocialAccounts = class extends BaseSocialAccounts {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/ssh-signing-keys.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/ssh-signing-keys.mjs
 var BaseSSHSigningKeys = /* @__PURE__ */ (() => {
   class BaseSSHSigningKeys2 extends APIResource {
     /**
@@ -35250,7 +35282,7 @@ var BaseSSHSigningKeys = /* @__PURE__ */ (() => {
 var SSHSigningKeys = class extends BaseSSHSigningKeys {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/codespaces/exports.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/codespaces/exports.mjs
 var BaseExports = /* @__PURE__ */ (() => {
   class BaseExports2 extends APIResource {
     /**
@@ -35303,7 +35335,7 @@ var BaseExports = /* @__PURE__ */ (() => {
 var Exports = class extends BaseExports {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/codespaces/secrets/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/codespaces/secrets/repositories.mjs
 var BaseRepositories8 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -35408,7 +35440,7 @@ var BaseRepositories8 = /* @__PURE__ */ (() => {
 var Repositories8 = class extends BaseRepositories8 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/codespaces/secrets/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/codespaces/secrets/secrets.mjs
 var BaseSecrets8 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -35535,7 +35567,7 @@ var Secrets8 = /* @__PURE__ */ (() => {
   return Secrets9;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/codespaces/codespaces.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/codespaces/codespaces.mjs
 var BaseCodespaces4 = /* @__PURE__ */ (() => {
   class BaseCodespaces5 extends APIResource {
     /**
@@ -35719,7 +35751,7 @@ var Codespaces4 = /* @__PURE__ */ (() => {
   return Codespaces5;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/installations/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/installations/repositories.mjs
 var BaseRepositories9 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -35794,7 +35826,7 @@ var BaseRepositories9 = /* @__PURE__ */ (() => {
 var Repositories9 = class extends BaseRepositories9 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/installations/installations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/installations/installations.mjs
 var BaseInstallations2 = /* @__PURE__ */ (() => {
   class BaseInstallations3 extends APIResource {
     /**
@@ -35835,7 +35867,7 @@ var Installations2 = /* @__PURE__ */ (() => {
   return Installations3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/memberships/orgs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/memberships/orgs.mjs
 var BaseOrgs2 = /* @__PURE__ */ (() => {
   class BaseOrgs3 extends APIResource {
     /**
@@ -35896,7 +35928,7 @@ var BaseOrgs2 = /* @__PURE__ */ (() => {
 var Orgs2 = class extends BaseOrgs2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/memberships/memberships.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/memberships/memberships.mjs
 var BaseMemberships3 = /* @__PURE__ */ (() => {
   class BaseMemberships4 extends APIResource {
   }
@@ -35918,7 +35950,7 @@ var Memberships3 = /* @__PURE__ */ (() => {
   return Memberships4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/migrations/archive.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/migrations/archive.mjs
 var BaseArchive2 = /* @__PURE__ */ (() => {
   class BaseArchive3 extends APIResource {
     /**
@@ -35990,7 +36022,7 @@ var BaseArchive2 = /* @__PURE__ */ (() => {
 var Archive2 = class extends BaseArchive2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/migrations/repos.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/migrations/repos.mjs
 var BaseRepos5 = /* @__PURE__ */ (() => {
   class BaseRepos6 extends APIResource {
     /**
@@ -36027,7 +36059,7 @@ var BaseRepos5 = /* @__PURE__ */ (() => {
 var Repos5 = class extends BaseRepos5 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/migrations/migrations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/migrations/migrations.mjs
 var BaseMigrations2 = /* @__PURE__ */ (() => {
   class BaseMigrations3 extends APIResource {
     /**
@@ -36119,7 +36151,7 @@ var Migrations2 = /* @__PURE__ */ (() => {
   return Migrations3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/packages/versions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/packages/versions.mjs
 var BaseVersions2 = /* @__PURE__ */ (() => {
   class BaseVersions4 extends APIResource {
     /**
@@ -36234,7 +36266,7 @@ var BaseVersions2 = /* @__PURE__ */ (() => {
 var Versions2 = class extends BaseVersions2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/packages/packages.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/packages/packages.mjs
 var BasePackages2 = /* @__PURE__ */ (() => {
   class BasePackages3 extends APIResource {
     /**
@@ -36366,7 +36398,7 @@ var Packages2 = /* @__PURE__ */ (() => {
   return Packages3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/settings/billing.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/settings/billing.mjs
 var BaseBilling4 = /* @__PURE__ */ (() => {
   class BaseBilling5 extends APIResource {
     /**
@@ -36447,7 +36479,7 @@ var BaseBilling4 = /* @__PURE__ */ (() => {
 var Billing4 = class extends BaseBilling4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/settings/settings.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/settings/settings.mjs
 var BaseSettings3 = /* @__PURE__ */ (() => {
   class BaseSettings4 extends APIResource {
   }
@@ -36469,7 +36501,7 @@ var Settings3 = /* @__PURE__ */ (() => {
   return Settings4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/users.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/users.mjs
 var BaseUsers3 = /* @__PURE__ */ (() => {
   class BaseUsers4 extends APIResource {
     /**
@@ -36817,7 +36849,7 @@ var Users3 = /* @__PURE__ */ (() => {
   return Users4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/versions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/versions.mjs
 var BaseVersions3 = /* @__PURE__ */ (() => {
   class BaseVersions4 extends APIResource {
     /**
@@ -36833,7 +36865,7 @@ var BaseVersions3 = /* @__PURE__ */ (() => {
 var Versions3 = class extends BaseVersions3 {
 };
 
-// node_modules/@stainless-api/github-internal/internal/utils/env.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/utils/env.mjs
 var readEnv = (env) => {
   if (typeof globalThis.process !== "undefined") {
     return globalThis.process.env?.[env]?.trim() ?? void 0;
@@ -36844,7 +36876,7 @@ var readEnv = (env) => {
   return void 0;
 };
 
-// node_modules/@stainless-api/github-internal/lib/auth.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/lib/auth.mjs
 var import_jsonwebtoken = __toESM(require_jsonwebtoken(), 1);
 async function getAuthToken({ authMethods, owner, repo, logger: logger2 }) {
   const method = authMethods.find((method2) => method2.owner === owner) ?? authMethods.at(-1);
@@ -36891,7 +36923,7 @@ async function getAppToken(method) {
   return { authToken: appToken, expires: appTokenExpires };
 }
 
-// node_modules/@stainless-api/github-internal/client.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/client.mjs
 var _BaseGitHub_instances;
 var _BaseGitHub_encoder;
 var _BaseGitHub_baseURLOverridden;
@@ -37396,7 +37428,7 @@ var GitHub = /* @__PURE__ */ (() => {
   return GitHub2;
 })();
 
-// node_modules/@stainless-api/github-internal/tree-shakable.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/tree-shakable.mjs
 function createClient(options) {
   const client = new BaseGitHub(options);
   for (const ResourceClass of options.resources) {
@@ -38541,7 +38573,7 @@ function makeCommitMessageConventional(message) {
   return message;
 }
 
-// node_modules/nano-spawn/source/context.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/context.js
 var import_node_process = __toESM(require("node:process"), 1);
 var import_node_util = require("node:util");
 var getContext = (raw) => ({
@@ -38551,7 +38583,7 @@ var getContext = (raw) => ({
 });
 var getCommandPart = (part) => /[^\w./-]/.test(part) ? `'${part.replaceAll("'", "'\\''")}'` : part;
 
-// node_modules/nano-spawn/source/options.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/options.js
 var import_node_path = __toESM(require("node:path"), 1);
 var import_node_url = require("node:url");
 var import_node_process2 = __toESM(require("node:process"), 1);
@@ -38583,12 +38615,12 @@ var addLocalPath = ({ Path = "", PATH = Path, ...env }, cwd) => {
 };
 var getLocalPaths = (localPaths, localPath) => localPaths.at(-1) === localPath ? localPaths : getLocalPaths([...localPaths, localPath], import_node_path.default.resolve(localPath, ".."));
 
-// node_modules/nano-spawn/source/spawn.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/spawn.js
 var import_node_child_process = require("node:child_process");
 var import_node_events2 = require("node:events");
 var import_node_process5 = __toESM(require("node:process"), 1);
 
-// node_modules/nano-spawn/source/windows.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/windows.js
 var import_promises = __toESM(require("node:fs/promises"), 1);
 var import_node_path2 = __toESM(require("node:path"), 1);
 var import_node_process3 = __toESM(require("node:process"), 1);
@@ -38622,7 +38654,7 @@ var exeExtensions = [".exe", ".com"];
 var escapeArgument = (argument) => escapeFile(escapeFile(`"${argument.replaceAll(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1")}"`));
 var escapeFile = (file) => file.replaceAll(/([()\][%!^"`<>&|;, *?])/g, "^$1");
 
-// node_modules/nano-spawn/source/result.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/result.js
 var import_node_events = require("node:events");
 var import_node_process4 = __toESM(require("node:process"), 1);
 var getResult = async (nodeChildProcess, { input }, context) => {
@@ -38681,7 +38713,7 @@ var getOutputs = ({ state: { stdout, stderr, output }, command, start }) => ({
 });
 var getOutput = (output) => output.at(-1) === "\n" ? output.slice(0, output.at(-2) === "\r" ? -2 : -1) : output;
 
-// node_modules/nano-spawn/source/spawn.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/spawn.js
 var spawnSubprocess = async (file, commandArguments, options, context) => {
   try {
     if (["node", "node.exe"].includes(file.toLowerCase())) {
@@ -38715,7 +38747,7 @@ var bufferOutput = (stream, { state }, streamName) => {
   }
 };
 
-// node_modules/nano-spawn/source/pipe.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/pipe.js
 var import_promises2 = require("node:stream/promises");
 var handlePipe = async (subprocesses) => {
   const [[from, to]] = await Promise.all([Promise.allSettled(subprocesses), pipeStreams(subprocesses)]);
@@ -38749,7 +38781,7 @@ var closeStdin = async (nodeChildProcess) => {
   stdin.end();
 };
 
-// node_modules/nano-spawn/source/iterable.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/iterable.js
 var readline = __toESM(require("node:readline/promises"), 1);
 var lineIterator = async function* (subprocess, { state }, streamName) {
   if (state.isIterating === false) {
@@ -38799,7 +38831,7 @@ var getNext = async (iterator) => {
   }
 };
 
-// node_modules/nano-spawn/source/index.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/index.js
 function spawn2(file, second, third, previous) {
   const [commandArguments = [], options = {}] = Array.isArray(second) ? [second, third] : [[], second];
   const context = getContext([file, ...commandArguments]);
@@ -38942,7 +38974,39 @@ async function isConfigChanged({
   return changed;
 }
 
-// node_modules/diff/libesm/diff/base.js
+// src/resolve.ts
+async function resolveProject(client, projectInput) {
+  if (projectInput) {
+    return { projectName: projectInput, orgName: void 0 };
+  }
+  const page = await client.projects.list({ limit: 6 });
+  const projects = page.data;
+  if (projects.length === 0) {
+    throw new Error(
+      "No projects found for the given API key. Please specify the `project` input explicitly."
+    );
+  }
+  if (projects.length === 1) {
+    const project = projects[0];
+    logger.info(`Auto-detected project: ${project.slug}`);
+    return { projectName: project.slug, orgName: project.org };
+  }
+  const slugs = projects.slice(0, 5).map((p) => p.slug).join(", ");
+  const suffix = projects.length > 5 ? ", ..." : "";
+  throw new Error(
+    `Multiple projects found: ${slugs}${suffix}. Please specify the \`project\` input explicitly.`
+  );
+}
+async function resolveOrg(client, orgName) {
+  if (orgName) {
+    return orgName;
+  }
+  const project = await client.projects.retrieve();
+  logger.info(`Auto-detected org: ${project.org}`);
+  return project.org;
+}
+
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/diff/base.js
 var Diff = class {
   diff(oldStr, newStr, options = {}) {
     let callback;
@@ -39144,7 +39208,7 @@ var Diff = class {
   }
 };
 
-// node_modules/diff/libesm/util/string.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/util/string.js
 function hasOnlyWinLineEndings(string) {
   return string.includes("\r\n") && !string.startsWith("\n") && !string.match(/[^\r]\n/);
 }
@@ -39152,7 +39216,7 @@ function hasOnlyUnixLineEndings(string) {
   return !string.includes("\r\n") && string.includes("\n");
 }
 
-// node_modules/diff/libesm/diff/line.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/diff/line.js
 var LineDiff = class extends Diff {
   constructor() {
     super(...arguments);
@@ -39200,7 +39264,7 @@ function tokenize(value, options) {
   return retLines;
 }
 
-// node_modules/diff/libesm/patch/line-endings.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/patch/line-endings.js
 function unixToWin(patch) {
   if (Array.isArray(patch)) {
     return patch.map((p) => unixToWin(p));
@@ -39232,7 +39296,7 @@ function isWin(patch) {
   })));
 }
 
-// node_modules/diff/libesm/patch/parse.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/patch/parse.js
 function parsePatch(uniDiff) {
   const diffstr = uniDiff.split(/\n/), list = [];
   let i = 0;
@@ -39337,7 +39401,7 @@ function parsePatch(uniDiff) {
   return list;
 }
 
-// node_modules/diff/libesm/util/distance-iterator.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/util/distance-iterator.js
 function distance_iterator_default(start, minLine, maxLine) {
   let wantForward = true, backwardExhausted = false, forwardExhausted = false, localOffset = 1;
   return function iterator() {
@@ -39366,7 +39430,7 @@ function distance_iterator_default(start, minLine, maxLine) {
   };
 }
 
-// node_modules/diff/libesm/patch/apply.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/patch/apply.js
 function applyPatch(source, patch, options = {}) {
   let patches;
   if (typeof patch === "string") {
@@ -39515,7 +39579,7 @@ function applyStructuredPatch(source, patch, options = {}) {
   return resultLines.join("\n");
 }
 
-// node_modules/diff/libesm/patch/create.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/patch/create.js
 var INCLUDE_HEADERS = {
   includeIndex: true,
   includeUnderline: true,
@@ -39698,7 +39762,7 @@ function splitLines(text) {
   return result;
 }
 
-// node_modules/@stainless-api/sdk/internal/tslib.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/tslib.mjs
 function __classPrivateFieldSet2(receiver, state, value, kind, f) {
   if (kind === "m")
     throw new TypeError("Private method is not writable");
@@ -39716,7 +39780,7 @@ function __classPrivateFieldGet2(receiver, state, kind, f) {
   return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 }
 
-// node_modules/@stainless-api/sdk/internal/utils/uuid.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/uuid.mjs
 var uuid42 = function() {
   const { crypto: crypto2 } = globalThis;
   if (crypto2?.randomUUID) {
@@ -39728,7 +39792,7 @@ var uuid42 = function() {
   return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) => (+c ^ randomByte() & 15 >> +c / 4).toString(16));
 };
 
-// node_modules/@stainless-api/sdk/internal/errors.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/errors.mjs
 function isAbortError2(err) {
   return typeof err === "object" && err !== null && // Spec-compliant fetch implementations
   ("name" in err && err.name === "AbortError" || // Expo fetch
@@ -39759,7 +39823,7 @@ var castToError2 = (err) => {
   return new Error(err);
 };
 
-// node_modules/@stainless-api/sdk/core/error.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/error.mjs
 var StainlessError = class extends Error {
 };
 var APIError2 = class _APIError extends StainlessError {
@@ -39848,7 +39912,7 @@ var RateLimitError2 = class extends APIError2 {
 var InternalServerError2 = class extends APIError2 {
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/values.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/values.mjs
 var startsWithSchemeRegexp2 = /^[a-z][a-z0-9+.-]*:/i;
 var isAbsoluteURL2 = (url) => {
   return startsWithSchemeRegexp2.test(url);
@@ -39888,13 +39952,13 @@ var safeJSON2 = (text) => {
   }
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/sleep.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/sleep.mjs
 var sleep2 = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-// node_modules/@stainless-api/sdk/version.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/version.mjs
 var VERSION2 = "0.1.0-alpha.19";
 
-// node_modules/@stainless-api/sdk/internal/detect-platform.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/detect-platform.mjs
 function getDetectedPlatform2() {
   if (typeof Deno !== "undefined" && Deno.build != null) {
     return "deno";
@@ -40020,7 +40084,7 @@ var getPlatformHeaders2 = () => {
   return _platformHeaders2 ?? (_platformHeaders2 = getPlatformProperties2());
 };
 
-// node_modules/@stainless-api/sdk/internal/shims.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/shims.mjs
 function getDefaultFetch2() {
   if (typeof fetch !== "undefined") {
     return fetch;
@@ -40065,7 +40129,7 @@ async function CancelReadableStream2(stream) {
   await cancelPromise;
 }
 
-// node_modules/@stainless-api/sdk/internal/request-options.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/request-options.mjs
 var FallbackEncoder2 = ({ headers, body }) => {
   return {
     bodyHeaders: {
@@ -40075,7 +40139,7 @@ var FallbackEncoder2 = ({ headers, body }) => {
   };
 };
 
-// node_modules/@stainless-api/sdk/internal/qs/formats.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/qs/formats.mjs
 var default_format2 = "RFC3986";
 var default_formatter2 = (v) => String(v);
 var formatters2 = {
@@ -40084,7 +40148,7 @@ var formatters2 = {
 };
 var RFC17382 = "RFC1738";
 
-// node_modules/@stainless-api/sdk/internal/qs/utils.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/qs/utils.mjs
 var has2 = (obj, key) => (has2 = Object.hasOwn ?? Function.prototype.call.bind(Object.prototype.hasOwnProperty), has2(obj, key));
 var hex_table2 = /* @__PURE__ */ (() => {
   const array = [];
@@ -40163,7 +40227,7 @@ function maybe_map2(val, fn) {
   return fn(val);
 }
 
-// node_modules/@stainless-api/sdk/internal/qs/stringify.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/qs/stringify.mjs
 var array_prefix_generators2 = {
   brackets(prefix) {
     return String(prefix) + "[]";
@@ -40441,7 +40505,7 @@ function stringify2(object, opts = {}) {
   return joined.length > 0 ? prefix + joined : "";
 }
 
-// node_modules/@stainless-api/sdk/internal/utils/log.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/log.mjs
 var levelNumbers2 = {
   off: 0,
   error: 200,
@@ -40514,7 +40578,7 @@ var formatRequestDetails2 = (details) => {
   return details;
 };
 
-// node_modules/@stainless-api/sdk/internal/parse.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/parse.mjs
 async function defaultParseResponse2(client, props) {
   const { response, requestLogID, retryOfRequestLogID, startTime } = props;
   const body = await (async () => {
@@ -40544,7 +40608,7 @@ async function defaultParseResponse2(client, props) {
   return body;
 }
 
-// node_modules/@stainless-api/sdk/core/api-promise.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/api-promise.mjs
 var _APIPromise_client2;
 var APIPromise2 = class _APIPromise extends Promise {
   constructor(client, responsePromise, parseResponse = defaultParseResponse2) {
@@ -40605,7 +40669,7 @@ var APIPromise2 = class _APIPromise extends Promise {
 };
 _APIPromise_client2 = /* @__PURE__ */ new WeakMap();
 
-// node_modules/@stainless-api/sdk/core/pagination.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/pagination.mjs
 var _AbstractPage_client2;
 var AbstractPage2 = class {
   constructor(client, response, body, options) {
@@ -40686,7 +40750,7 @@ var Page = class extends AbstractPage2 {
   }
 };
 
-// node_modules/@stainless-api/sdk/internal/uploads.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/uploads.mjs
 var checkFileSupport2 = () => {
   if (typeof File === "undefined") {
     const { process: process7 } = globalThis;
@@ -40703,7 +40767,7 @@ function getName2(value) {
 }
 var isAsyncIterable2 = (value) => value != null && typeof value === "object" && typeof value[Symbol.asyncIterator] === "function";
 
-// node_modules/@stainless-api/sdk/internal/to-file.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/to-file.mjs
 var isBlobLike2 = (value) => value != null && typeof value === "object" && typeof value.size === "number" && typeof value.type === "string" && typeof value.text === "function" && typeof value.slice === "function" && typeof value.arrayBuffer === "function";
 var isFileLike2 = (value) => value != null && typeof value === "object" && typeof value.name === "string" && typeof value.lastModified === "number" && isBlobLike2(value);
 var isResponseLike2 = (value) => value != null && typeof value === "object" && typeof value.url === "string" && typeof value.blob === "function";
@@ -40755,14 +40819,14 @@ function propsForError2(value) {
   return `; props: [${props.map((p) => `"${p}"`).join(", ")}]`;
 }
 
-// node_modules/@stainless-api/sdk/core/resource.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/resource.mjs
 var APIResource2 = class {
   constructor(client) {
     this._client = client;
   }
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/path.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/path.mjs
 function encodeURIPath2(str) {
   return str.replace(/[^A-Za-z0-9\-._~!$&'()*+,;=:@]+/g, encodeURIComponent);
 }
@@ -40817,7 +40881,7 @@ ${underline}`);
 };
 var path5 = /* @__PURE__ */ createPathTagFunction2(encodeURIPath2);
 
-// node_modules/@stainless-api/sdk/resources/builds/diagnostics.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/builds/diagnostics.mjs
 var Diagnostics = class extends APIResource2 {
   /**
    * Get the list of diagnostics for a given build.
@@ -40833,7 +40897,7 @@ var Diagnostics = class extends APIResource2 {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/builds/target-outputs.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/builds/target-outputs.mjs
 var TargetOutputs = class extends APIResource2 {
   /**
    * Retrieve a method to download an output for a given build target.
@@ -40852,7 +40916,7 @@ var TargetOutputs = class extends APIResource2 {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/builds/builds.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/builds/builds.mjs
 var Builds2 = class extends APIResource2 {
   constructor() {
     super(...arguments);
@@ -40904,7 +40968,7 @@ var Builds2 = class extends APIResource2 {
 Builds2.Diagnostics = Diagnostics;
 Builds2.TargetOutputs = TargetOutputs;
 
-// node_modules/@stainless-api/sdk/resources/orgs.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/orgs.mjs
 var Orgs3 = class extends APIResource2 {
   /**
    * Retrieve an organization by name.
@@ -40920,7 +40984,7 @@ var Orgs3 = class extends APIResource2 {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/projects/branches.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/projects/branches.mjs
 var Branches2 = class extends APIResource2 {
   /**
    * Create a new branch for a project.
@@ -40985,7 +41049,7 @@ var Branches2 = class extends APIResource2 {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/projects/configs.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/projects/configs.mjs
 var Configs = class extends APIResource2 {
   /**
    * Retrieve the configuration files for a given project.
@@ -41003,7 +41067,7 @@ var Configs = class extends APIResource2 {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/projects/projects.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/projects/projects.mjs
 var Projects = class extends APIResource2 {
   constructor() {
     super(...arguments);
@@ -41040,7 +41104,7 @@ var Projects = class extends APIResource2 {
 Projects.Branches = Branches2;
 Projects.Configs = Configs;
 
-// node_modules/@stainless-api/sdk/internal/headers.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/headers.mjs
 var brand_privateNullableHeaders2 = /* @__PURE__ */ Symbol("brand.privateNullableHeaders");
 function* iterateHeaders2(headers) {
   if (!headers)
@@ -41103,7 +41167,7 @@ var buildHeaders2 = (newHeaders) => {
   return { [brand_privateNullableHeaders2]: true, values: targetHeaders, nulls: nullHeaders };
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/env.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/env.mjs
 var readEnv2 = (env) => {
   if (typeof globalThis.process !== "undefined") {
     return globalThis.process.env?.[env]?.trim() ?? void 0;
@@ -41114,7 +41178,7 @@ var readEnv2 = (env) => {
   return void 0;
 };
 
-// node_modules/@stainless-api/sdk/lib/unwrap.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/lib/unwrap.mjs
 async function unwrapFile(value) {
   if (value === null) {
     return null;
@@ -41126,7 +41190,7 @@ async function unwrapFile(value) {
   return response.text();
 }
 
-// node_modules/@stainless-api/sdk/client.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/client.mjs
 var _Stainless_instances;
 var _a2;
 var _Stainless_encoder;
@@ -41627,18 +41691,23 @@ function wrapAction(actionType, fn) {
   return async () => {
     let stainless;
     let projectName;
+    let orgName;
     try {
-      projectName = getInput("project", { required: true });
+      const projectInput = getInput("project", { required: false }) || void 0;
       const auth = await getStainlessAuth();
-      stainless = getStainlessClient(actionType, {
-        project: projectName,
+      const client = getStainlessClient(actionType, {
         apiKey: auth.key,
         logLevel: "warn",
         fetch: createAutoRefreshFetch(auth, getStainlessAuth)
       });
-      await fn(stainless);
+      const resolved = await resolveProject(client, projectInput);
+      projectName = resolved.projectName;
+      stainless = client.withOptions({ project: projectName });
+      orgName = getInput("org", { required: false }) || resolved.orgName;
+      await fn({ stainless, projectName, orgName });
       await maybeReportResult({
         stainless,
+        orgName,
         projectName,
         actionType,
         successOrError: { result: "success" }
@@ -41648,6 +41717,7 @@ function wrapAction(actionType, fn) {
       if (stainless) {
         await maybeReportResult({
           stainless,
+          orgName,
           projectName,
           actionType,
           successOrError: serializeError(error)
@@ -41668,6 +41738,7 @@ function serializeError(error) {
 }
 async function maybeReportResult({
   stainless,
+  orgName,
   projectName,
   actionType,
   successOrError
@@ -41677,6 +41748,7 @@ async function maybeReportResult({
   }
   try {
     const body = {
+      org: orgName,
       project: projectName,
       build_ids: [...accumulatedBuildIds],
       action_type: actionType,
@@ -42023,9 +42095,8 @@ async function* pollBuild({
 }
 
 // src/merge.ts
-var main = wrapAction("merge", async (stainless) => {
-  const orgName = getInput("org", { required: false });
-  const projectName = getInput("project", { required: true });
+var main = wrapAction("merge", async (ctx) => {
+  const { stainless, projectName } = ctx;
   const oasPath = getInput("oas_path", { required: false });
   const configPath = getInput("config_path", { required: false }) || void 0;
   const defaultCommitMessage = getInput("commit_message", { required: true });
@@ -42054,11 +42125,7 @@ var main = wrapAction("merge", async (stainless) => {
       "This action requires a pull request number to make a comment."
     );
   }
-  if (makeComment && !orgName) {
-    throw new Error(
-      "This action requires an organization name to make a comment."
-    );
-  }
+  const orgName = makeComment ? await resolveOrg(stainless, ctx.orgName) : ctx.orgName;
   const { savedSha } = await saveConfig({
     oasPath,
     configPath

--- a/dist/prepareCombine.js
+++ b/dist/prepareCombine.js
@@ -25,9 +25,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/yaml/dist/nodes/identity.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/identity.js
 var require_identity = __commonJS({
-  "node_modules/yaml/dist/nodes/identity.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/identity.js"(exports2) {
     "use strict";
     var ALIAS = Symbol.for("yaml.alias");
     var DOC = Symbol.for("yaml.document");
@@ -82,9 +82,9 @@ var require_identity = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/visit.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/visit.js
 var require_visit = __commonJS({
-  "node_modules/yaml/dist/visit.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/visit.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var BREAK = Symbol("break visit");
@@ -240,9 +240,9 @@ var require_visit = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/directives.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/directives.js
 var require_directives = __commonJS({
-  "node_modules/yaml/dist/doc/directives.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/directives.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -411,9 +411,9 @@ var require_directives = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/anchors.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/anchors.js
 var require_anchors = __commonJS({
-  "node_modules/yaml/dist/doc/anchors.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/anchors.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -481,9 +481,9 @@ var require_anchors = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/applyReviver.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/applyReviver.js
 var require_applyReviver = __commonJS({
-  "node_modules/yaml/dist/doc/applyReviver.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/applyReviver.js"(exports2) {
     "use strict";
     function applyReviver(reviver, obj, key, val) {
       if (val && typeof val === "object") {
@@ -531,9 +531,9 @@ var require_applyReviver = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/toJS.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/toJS.js
 var require_toJS = __commonJS({
-  "node_modules/yaml/dist/nodes/toJS.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/toJS.js"(exports2) {
     "use strict";
     var identity = require_identity();
     function toJS(value, arg, ctx) {
@@ -561,9 +561,9 @@ var require_toJS = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Node.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Node.js
 var require_Node = __commonJS({
-  "node_modules/yaml/dist/nodes/Node.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Node.js"(exports2) {
     "use strict";
     var applyReviver = require_applyReviver();
     var identity = require_identity();
@@ -602,9 +602,9 @@ var require_Node = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Alias.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Alias.js
 var require_Alias = __commonJS({
-  "node_modules/yaml/dist/nodes/Alias.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Alias.js"(exports2) {
     "use strict";
     var anchors = require_anchors();
     var visit = require_visit();
@@ -663,7 +663,7 @@ var require_Alias = __commonJS({
           toJS.toJS(source, null, ctx);
           data = anchors2.get(source);
         }
-        if (!data || data.res === void 0) {
+        if (data?.res === void 0) {
           const msg = "This should not happen: Alias anchor was not resolved?";
           throw new ReferenceError(msg);
         }
@@ -716,9 +716,9 @@ var require_Alias = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Scalar.js
 var require_Scalar = __commonJS({
-  "node_modules/yaml/dist/nodes/Scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Scalar.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Node = require_Node();
@@ -746,9 +746,9 @@ var require_Scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/createNode.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/createNode.js
 var require_createNode = __commonJS({
-  "node_modules/yaml/dist/doc/createNode.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/createNode.js"(exports2) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -821,9 +821,9 @@ var require_createNode = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Collection.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Collection.js
 var require_Collection = __commonJS({
-  "node_modules/yaml/dist/nodes/Collection.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Collection.js"(exports2) {
     "use strict";
     var createNode = require_createNode();
     var identity = require_identity();
@@ -964,9 +964,9 @@ var require_Collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyComment.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyComment.js
 var require_stringifyComment = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyComment.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyComment.js"(exports2) {
     "use strict";
     var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
     function indentComment(comment, indent) {
@@ -981,9 +981,9 @@ var require_stringifyComment = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/foldFlowLines.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/foldFlowLines.js
 var require_foldFlowLines = __commonJS({
-  "node_modules/yaml/dist/stringify/foldFlowLines.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/foldFlowLines.js"(exports2) {
     "use strict";
     var FOLD_FLOW = "flow";
     var FOLD_BLOCK = "block";
@@ -1117,9 +1117,9 @@ ${indent}${text.slice(fold + 1, end2)}`;
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyString.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyString.js
 var require_stringifyString = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyString.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyString.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var foldFlowLines = require_foldFlowLines();
@@ -1400,9 +1400,9 @@ ${indent}`);
   }
 });
 
-// node_modules/yaml/dist/stringify/stringify.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringify.js
 var require_stringify = __commonJS({
-  "node_modules/yaml/dist/stringify/stringify.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringify.js"(exports2) {
     "use strict";
     var anchors = require_anchors();
     var identity = require_identity();
@@ -1523,9 +1523,9 @@ ${ctx.indent}${str}`;
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyPair.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyPair.js
 var require_stringifyPair = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyPair.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyPair.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -1613,7 +1613,7 @@ ${indent}:`;
 ${stringifyComment.indentComment(cs, ctx.indent)}`;
         }
         if (valueStr === "" && !ctx.inFlow) {
-          if (ws === "\n")
+          if (ws === "\n" && valueComment)
             ws = "\n\n";
         } else {
           ws += `
@@ -1656,9 +1656,9 @@ ${ctx.indent}`;
   }
 });
 
-// node_modules/yaml/dist/log.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/log.js
 var require_log = __commonJS({
-  "node_modules/yaml/dist/log.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/log.js"(exports2) {
     "use strict";
     var node_process = require("process");
     function debug(logLevel, ...messages) {
@@ -1678,9 +1678,9 @@ var require_log = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/merge.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/merge.js
 var require_merge = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -1735,9 +1735,9 @@ var require_merge = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/addPairToJSMap.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/addPairToJSMap.js
 var require_addPairToJSMap = __commonJS({
-  "node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports2) {
     "use strict";
     var log = require_log();
     var merge = require_merge();
@@ -1799,9 +1799,9 @@ var require_addPairToJSMap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Pair.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Pair.js
 var require_Pair = __commonJS({
-  "node_modules/yaml/dist/nodes/Pair.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Pair.js"(exports2) {
     "use strict";
     var createNode = require_createNode();
     var stringifyPair = require_stringifyPair();
@@ -1839,9 +1839,9 @@ var require_Pair = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyCollection.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyCollection.js
 var require_stringifyCollection = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyCollection.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyCollection.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -1983,9 +1983,9 @@ ${indent}${end}`;
   }
 });
 
-// node_modules/yaml/dist/nodes/YAMLMap.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLMap.js
 var require_YAMLMap = __commonJS({
-  "node_modules/yaml/dist/nodes/YAMLMap.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLMap.js"(exports2) {
     "use strict";
     var stringifyCollection = require_stringifyCollection();
     var addPairToJSMap = require_addPairToJSMap();
@@ -2127,9 +2127,9 @@ var require_YAMLMap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/map.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/map.js
 var require_map = __commonJS({
-  "node_modules/yaml/dist/schema/common/map.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/map.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var YAMLMap = require_YAMLMap();
@@ -2149,9 +2149,9 @@ var require_map = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/YAMLSeq.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLSeq.js
 var require_YAMLSeq = __commonJS({
-  "node_modules/yaml/dist/nodes/YAMLSeq.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLSeq.js"(exports2) {
     "use strict";
     var createNode = require_createNode();
     var stringifyCollection = require_stringifyCollection();
@@ -2265,9 +2265,9 @@ var require_YAMLSeq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/seq.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/seq.js
 var require_seq = __commonJS({
-  "node_modules/yaml/dist/schema/common/seq.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/seq.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var YAMLSeq = require_YAMLSeq();
@@ -2287,9 +2287,9 @@ var require_seq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/string.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/string.js
 var require_string = __commonJS({
-  "node_modules/yaml/dist/schema/common/string.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/string.js"(exports2) {
     "use strict";
     var stringifyString = require_stringifyString();
     var string = {
@@ -2306,9 +2306,9 @@ var require_string = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/null.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/null.js
 var require_null = __commonJS({
-  "node_modules/yaml/dist/schema/common/null.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/null.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var nullTag = {
@@ -2324,9 +2324,9 @@ var require_null = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/bool.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/bool.js
 var require_bool = __commonJS({
-  "node_modules/yaml/dist/schema/core/bool.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/bool.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var boolTag = {
@@ -2348,9 +2348,9 @@ var require_bool = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyNumber.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyNumber.js
 var require_stringifyNumber = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyNumber.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyNumber.js"(exports2) {
     "use strict";
     function stringifyNumber({ format, minFractionDigits, tag, value }) {
       if (typeof value === "bigint")
@@ -2358,7 +2358,7 @@ var require_stringifyNumber = __commonJS({
       const num = typeof value === "number" ? value : Number(value);
       if (!isFinite(num))
         return isNaN(num) ? ".nan" : num < 0 ? "-.inf" : ".inf";
-      let n = JSON.stringify(value);
+      let n = Object.is(value, -0) ? "-0" : JSON.stringify(value);
       if (!format && minFractionDigits && (!tag || tag === "tag:yaml.org,2002:float") && /^\d/.test(n)) {
         let i = n.indexOf(".");
         if (i < 0) {
@@ -2375,9 +2375,9 @@ var require_stringifyNumber = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/float.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/float.js
 var require_float = __commonJS({
-  "node_modules/yaml/dist/schema/core/float.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/float.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -2421,9 +2421,9 @@ var require_float = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/int.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/int.js
 var require_int = __commonJS({
-  "node_modules/yaml/dist/schema/core/int.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/int.js"(exports2) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -2466,9 +2466,9 @@ var require_int = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/schema.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/schema.js
 var require_schema = __commonJS({
-  "node_modules/yaml/dist/schema/core/schema.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/schema.js"(exports2) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -2494,9 +2494,9 @@ var require_schema = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/json/schema.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/json/schema.js
 var require_schema2 = __commonJS({
-  "node_modules/yaml/dist/schema/json/schema.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/json/schema.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var map = require_map();
@@ -2561,9 +2561,9 @@ var require_schema2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/binary.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/binary.js
 var require_binary = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports2) {
     "use strict";
     var node_buffer = require("buffer");
     var Scalar = require_Scalar();
@@ -2627,9 +2627,9 @@ var require_binary = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/pairs.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/pairs.js
 var require_pairs = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -2705,9 +2705,9 @@ ${cn.comment}` : item.comment;
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/omap.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/omap.js
 var require_omap = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var toJS = require_toJS();
@@ -2783,9 +2783,9 @@ var require_omap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/bool.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/bool.js
 var require_bool2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     function boolStringify({ value, source }, ctx) {
@@ -2815,9 +2815,9 @@ var require_bool2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/float.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/float.js
 var require_float2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -2864,9 +2864,9 @@ var require_float2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/int.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/int.js
 var require_int2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports2) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -2943,9 +2943,9 @@ var require_int2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/set.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/set.js
 var require_set = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -3032,9 +3032,9 @@ var require_set = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
 var require_timestamp = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports2) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     function parseSexagesimal(str, asBigInt) {
@@ -3120,9 +3120,9 @@ var require_timestamp = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/schema.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/schema.js
 var require_schema3 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports2) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -3164,9 +3164,9 @@ var require_schema3 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/tags.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/tags.js
 var require_tags = __commonJS({
-  "node_modules/yaml/dist/schema/tags.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/tags.js"(exports2) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -3258,9 +3258,9 @@ var require_tags = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/Schema.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/Schema.js
 var require_Schema = __commonJS({
-  "node_modules/yaml/dist/schema/Schema.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/Schema.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var map = require_map();
@@ -3290,9 +3290,9 @@ var require_Schema = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyDocument.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyDocument.js
 var require_stringifyDocument = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyDocument.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyDocument.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -3370,9 +3370,9 @@ var require_stringifyDocument = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/Document.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/Document.js
 var require_Document = __commonJS({
-  "node_modules/yaml/dist/doc/Document.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/Document.js"(exports2) {
     "use strict";
     var Alias = require_Alias();
     var Collection = require_Collection();
@@ -3679,9 +3679,9 @@ var require_Document = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/errors.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/errors.js
 var require_errors = __commonJS({
-  "node_modules/yaml/dist/errors.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/errors.js"(exports2) {
     "use strict";
     var YAMLError = class extends Error {
       constructor(name, pos, code, message) {
@@ -3726,7 +3726,7 @@ var require_errors = __commonJS({
       if (/[^ ]/.test(lineStr)) {
         let count = 1;
         const end = error.linePos[1];
-        if (end && end.line === line && end.col > col) {
+        if (end?.line === line && end.col > col) {
           count = Math.max(1, Math.min(end.col - col, 80 - ci));
         }
         const pointer = " ".repeat(ci) + "^".repeat(count);
@@ -3744,9 +3744,9 @@ ${pointer}
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-props.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-props.js
 var require_resolve_props = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-props.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-props.js"(exports2) {
     "use strict";
     function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
       let spaceBefore = false;
@@ -3878,9 +3878,9 @@ var require_resolve_props = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-contains-newline.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-contains-newline.js
 var require_util_contains_newline = __commonJS({
-  "node_modules/yaml/dist/compose/util-contains-newline.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-contains-newline.js"(exports2) {
     "use strict";
     function containsNewline(key) {
       if (!key)
@@ -3920,9 +3920,9 @@ var require_util_contains_newline = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-flow-indent-check.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-flow-indent-check.js
 var require_util_flow_indent_check = __commonJS({
-  "node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports2) {
     "use strict";
     var utilContainsNewline = require_util_contains_newline();
     function flowIndentCheck(indent, fc, onError) {
@@ -3938,9 +3938,9 @@ var require_util_flow_indent_check = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-map-includes.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-map-includes.js
 var require_util_map_includes = __commonJS({
-  "node_modules/yaml/dist/compose/util-map-includes.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-map-includes.js"(exports2) {
     "use strict";
     var identity = require_identity();
     function mapIncludes(ctx, items, search) {
@@ -3954,9 +3954,9 @@ var require_util_map_includes = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-map.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-map.js
 var require_resolve_block_map = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-map.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-map.js"(exports2) {
     "use strict";
     var Pair = require_Pair();
     var YAMLMap = require_YAMLMap();
@@ -4062,9 +4062,9 @@ var require_resolve_block_map = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-seq.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-seq.js
 var require_resolve_block_seq = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-seq.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-seq.js"(exports2) {
     "use strict";
     var YAMLSeq = require_YAMLSeq();
     var resolveProps = require_resolve_props();
@@ -4089,7 +4089,7 @@ var require_resolve_block_seq = __commonJS({
         });
         if (!props.found) {
           if (props.anchor || props.tag || value) {
-            if (value && value.type === "block-seq")
+            if (value?.type === "block-seq")
               onError(props.end, "BAD_INDENT", "All sequence items must start at the same column");
             else
               onError(offset, "MISSING_CHAR", "Sequence item without - indicator");
@@ -4113,9 +4113,9 @@ var require_resolve_block_seq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-end.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-end.js
 var require_resolve_end = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-end.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-end.js"(exports2) {
     "use strict";
     function resolveEnd(end, offset, reqSpace, onError) {
       let comment = "";
@@ -4156,9 +4156,9 @@ var require_resolve_end = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-flow-collection.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-collection.js
 var require_resolve_flow_collection = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -4286,7 +4286,7 @@ var require_resolve_flow_collection = __commonJS({
                 onError(valueProps.found, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit flow sequence key");
             }
           } else if (value) {
-            if ("source" in value && value.source && value.source[0] === ":")
+            if ("source" in value && value.source?.[0] === ":")
               onError(value, "MISSING_CHAR", `Missing space after : in ${fcName}`);
             else
               onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
@@ -4323,7 +4323,7 @@ var require_resolve_flow_collection = __commonJS({
       const expectedEnd = isMap ? "}" : "]";
       const [ce, ...ee] = fc.end;
       let cePos = offset;
-      if (ce && ce.source === expectedEnd)
+      if (ce?.source === expectedEnd)
         cePos = ce.offset + ce.source.length;
       else {
         const name = fcName[0].toUpperCase() + fcName.substring(1);
@@ -4350,9 +4350,9 @@ var require_resolve_flow_collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-collection.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-collection.js
 var require_compose_collection = __commonJS({
-  "node_modules/yaml/dist/compose/compose-collection.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-collection.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -4390,7 +4390,7 @@ var require_compose_collection = __commonJS({
       let tag = ctx.schema.tags.find((t) => t.tag === tagName && t.collection === expType);
       if (!tag) {
         const kt = ctx.schema.knownTags[tagName];
-        if (kt && kt.collection === expType) {
+        if (kt?.collection === expType) {
           ctx.schema.tags.push(Object.assign({}, kt, { default: false }));
           tag = kt;
         } else {
@@ -4415,9 +4415,9 @@ var require_compose_collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-scalar.js
 var require_resolve_block_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     function resolveBlockScalar(ctx, scalar, onError) {
@@ -4598,9 +4598,9 @@ var require_resolve_block_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-flow-scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-scalar.js
 var require_resolve_flow_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports2) {
     "use strict";
     var Scalar = require_Scalar();
     var resolveEnd = require_resolve_end();
@@ -4817,9 +4817,9 @@ var require_resolve_flow_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-scalar.js
 var require_compose_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/compose-scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-scalar.js"(exports2) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -4898,9 +4898,9 @@ var require_compose_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-empty-scalar-position.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-empty-scalar-position.js
 var require_util_empty_scalar_position = __commonJS({
-  "node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports2) {
     "use strict";
     function emptyScalarPosition(offset, before, pos) {
       if (before) {
@@ -4928,9 +4928,9 @@ var require_util_empty_scalar_position = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-node.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-node.js
 var require_compose_node = __commonJS({
-  "node_modules/yaml/dist/compose/compose-node.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-node.js"(exports2) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -5029,9 +5029,9 @@ var require_compose_node = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-doc.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-doc.js
 var require_compose_doc = __commonJS({
-  "node_modules/yaml/dist/compose/compose-doc.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-doc.js"(exports2) {
     "use strict";
     var Document = require_Document();
     var composeNode = require_compose_node();
@@ -5072,9 +5072,9 @@ var require_compose_doc = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/composer.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/composer.js
 var require_composer = __commonJS({
-  "node_modules/yaml/dist/compose/composer.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/composer.js"(exports2) {
     "use strict";
     var node_process = require("process");
     var directives = require_directives();
@@ -5278,9 +5278,9 @@ ${end.comment}` : end.comment;
   }
 });
 
-// node_modules/yaml/dist/parse/cst-scalar.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-scalar.js
 var require_cst_scalar = __commonJS({
-  "node_modules/yaml/dist/parse/cst-scalar.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-scalar.js"(exports2) {
     "use strict";
     var resolveBlockScalar = require_resolve_block_scalar();
     var resolveFlowScalar = require_resolve_flow_scalar();
@@ -5463,9 +5463,9 @@ var require_cst_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst-stringify.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-stringify.js
 var require_cst_stringify = __commonJS({
-  "node_modules/yaml/dist/parse/cst-stringify.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-stringify.js"(exports2) {
     "use strict";
     var stringify = (cst) => "type" in cst ? stringifyToken(cst) : stringifyItem(cst);
     function stringifyToken(token) {
@@ -5524,9 +5524,9 @@ var require_cst_stringify = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst-visit.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-visit.js
 var require_cst_visit = __commonJS({
-  "node_modules/yaml/dist/parse/cst-visit.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-visit.js"(exports2) {
     "use strict";
     var BREAK = Symbol("break visit");
     var SKIP = Symbol("skip children");
@@ -5586,9 +5586,9 @@ var require_cst_visit = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst.js
 var require_cst = __commonJS({
-  "node_modules/yaml/dist/parse/cst.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst.js"(exports2) {
     "use strict";
     var cstScalar = require_cst_scalar();
     var cstStringify = require_cst_stringify();
@@ -5688,9 +5688,9 @@ var require_cst = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/lexer.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/lexer.js
 var require_lexer = __commonJS({
-  "node_modules/yaml/dist/parse/lexer.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/lexer.js"(exports2) {
     "use strict";
     var cst = require_cst();
     function isEmpty(ch) {
@@ -6267,9 +6267,9 @@ var require_lexer = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/line-counter.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/line-counter.js
 var require_line_counter = __commonJS({
-  "node_modules/yaml/dist/parse/line-counter.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/line-counter.js"(exports2) {
     "use strict";
     var LineCounter = class {
       constructor() {
@@ -6298,9 +6298,9 @@ var require_line_counter = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/parser.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/parser.js
 var require_parser = __commonJS({
-  "node_modules/yaml/dist/parse/parser.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/parser.js"(exports2) {
     "use strict";
     var node_process = require("process");
     var cst = require_cst();
@@ -6488,7 +6488,7 @@ var require_parser = __commonJS({
       }
       *step() {
         const top = this.peek(1);
-        if (this.type === "doc-end" && (!top || top.type !== "doc-end")) {
+        if (this.type === "doc-end" && top?.type !== "doc-end") {
           while (this.stack.length > 0)
             yield* this.pop();
           this.stack.push({
@@ -6966,7 +6966,7 @@ var require_parser = __commonJS({
           do {
             yield* this.pop();
             top = this.peek(1);
-          } while (top && top.type === "flow-collection");
+          } while (top?.type === "flow-collection");
         } else if (fc.end.length === 0) {
           switch (this.type) {
             case "comma":
@@ -7165,9 +7165,9 @@ var require_parser = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/public-api.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/public-api.js
 var require_public_api = __commonJS({
-  "node_modules/yaml/dist/public-api.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/public-api.js"(exports2) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -7262,9 +7262,9 @@ var require_public_api = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/index.js
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/index.js
 var require_dist = __commonJS({
-  "node_modules/yaml/dist/index.js"(exports2) {
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/index.js"(exports2) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -7529,7 +7529,7 @@ var logger = createLogger({ platform: detectPlatform() });
 var fs3 = __toESM(require("node:fs/promises"));
 var path4 = __toESM(require("node:path"));
 
-// node_modules/@isaacs/balanced-match/dist/esm/index.js
+// node_modules/.pnpm/@isaacs+balanced-match@4.0.1/node_modules/@isaacs/balanced-match/dist/esm/index.js
 var balanced = (a, b, str) => {
   const ma = a instanceof RegExp ? maybeMatch(a, str) : a;
   const mb = b instanceof RegExp ? maybeMatch(b, str) : b;
@@ -7582,7 +7582,7 @@ var range = (a, b, str) => {
   return result;
 };
 
-// node_modules/@isaacs/brace-expansion/dist/esm/index.js
+// node_modules/.pnpm/@isaacs+brace-expansion@5.0.0/node_modules/@isaacs/brace-expansion/dist/esm/index.js
 var escSlash = "\0SLASH" + Math.random() + "\0";
 var escOpen = "\0OPEN" + Math.random() + "\0";
 var escClose = "\0CLOSE" + Math.random() + "\0";
@@ -7740,7 +7740,7 @@ function expand_(str, isTop) {
   return expansions;
 }
 
-// node_modules/glob/node_modules/minimatch/dist/esm/assert-valid-pattern.js
+// node_modules/.pnpm/minimatch@10.1.1/node_modules/minimatch/dist/esm/assert-valid-pattern.js
 var MAX_PATTERN_LENGTH = 1024 * 64;
 var assertValidPattern = (pattern) => {
   if (typeof pattern !== "string") {
@@ -7751,7 +7751,7 @@ var assertValidPattern = (pattern) => {
   }
 };
 
-// node_modules/glob/node_modules/minimatch/dist/esm/brace-expressions.js
+// node_modules/.pnpm/minimatch@10.1.1/node_modules/minimatch/dist/esm/brace-expressions.js
 var posixClasses = {
   "[:alnum:]": ["\\p{L}\\p{Nl}\\p{Nd}", true],
   "[:alpha:]": ["\\p{L}\\p{Nl}", true],
@@ -7860,7 +7860,7 @@ var parseClass = (glob2, position) => {
   return [comb, uflag, endPos - pos, true];
 };
 
-// node_modules/glob/node_modules/minimatch/dist/esm/unescape.js
+// node_modules/.pnpm/minimatch@10.1.1/node_modules/minimatch/dist/esm/unescape.js
 var unescape = (s, { windowsPathsNoEscape = false, magicalBraces = true } = {}) => {
   if (magicalBraces) {
     return windowsPathsNoEscape ? s.replace(/\[([^\/\\])\]/g, "$1") : s.replace(/((?!\\).|^)\[([^\/\\])\]/g, "$1$2").replace(/\\([^\/])/g, "$1");
@@ -7868,7 +7868,7 @@ var unescape = (s, { windowsPathsNoEscape = false, magicalBraces = true } = {}) 
   return windowsPathsNoEscape ? s.replace(/\[([^\/\\{}])\]/g, "$1") : s.replace(/((?!\\).|^)\[([^\/\\{}])\]/g, "$1$2").replace(/\\([^\/{}])/g, "$1");
 };
 
-// node_modules/glob/node_modules/minimatch/dist/esm/ast.js
+// node_modules/.pnpm/minimatch@10.1.1/node_modules/minimatch/dist/esm/ast.js
 var types = /* @__PURE__ */ new Set(["!", "?", "+", "*", "@"]);
 var isExtglobType = (c) => types.has(c);
 var startNoTraversal = "(?!(?:^|/)\\.\\.?(?:$|/))";
@@ -8344,7 +8344,7 @@ var AST = class _AST {
   }
 };
 
-// node_modules/glob/node_modules/minimatch/dist/esm/escape.js
+// node_modules/.pnpm/minimatch@10.1.1/node_modules/minimatch/dist/esm/escape.js
 var escape = (s, { windowsPathsNoEscape = false, magicalBraces = false } = {}) => {
   if (magicalBraces) {
     return windowsPathsNoEscape ? s.replace(/[?*()[\]{}]/g, "[$&]") : s.replace(/[?*()[\]\\{}]/g, "\\$&");
@@ -8352,7 +8352,7 @@ var escape = (s, { windowsPathsNoEscape = false, magicalBraces = false } = {}) =
   return windowsPathsNoEscape ? s.replace(/[?*()[\]]/g, "[$&]") : s.replace(/[?*()[\]\\]/g, "\\$&");
 };
 
-// node_modules/glob/node_modules/minimatch/dist/esm/index.js
+// node_modules/.pnpm/minimatch@10.1.1/node_modules/minimatch/dist/esm/index.js
 var minimatch = (p, pattern, options = {}) => {
   assertValidPattern(pattern);
   if (!options.nocomment && pattern.charAt(0) === "#") {
@@ -9081,10 +9081,10 @@ minimatch.Minimatch = Minimatch;
 minimatch.escape = escape;
 minimatch.unescape = unescape;
 
-// node_modules/glob/dist/esm/glob.js
+// node_modules/.pnpm/glob@11.1.0/node_modules/glob/dist/esm/glob.js
 var import_node_url2 = require("node:url");
 
-// node_modules/lru-cache/dist/esm/index.js
+// node_modules/.pnpm/lru-cache@11.2.5/node_modules/lru-cache/dist/esm/index.js
 var defaultPerf = typeof performance === "object" && performance && typeof performance.now === "function" ? performance : Date;
 var warned = /* @__PURE__ */ new Set();
 var PROCESS = typeof process === "object" && !!process ? process : {};
@@ -10129,6 +10129,7 @@ var LRUCache = class _LRUCache {
     const cb = (v2, updateCache = false) => {
       const { aborted } = ac.signal;
       const ignoreAbort = options.ignoreFetchAbort && v2 !== void 0;
+      const proceed = options.ignoreFetchAbort || !!(options.allowStaleOnFetchAbort && v2 !== void 0);
       if (options.status) {
         if (aborted && !updateCache) {
           options.status.fetchAborted = true;
@@ -10140,7 +10141,7 @@ var LRUCache = class _LRUCache {
         }
       }
       if (aborted && !ignoreAbort && !updateCache) {
-        return fetchFail(ac.signal.reason);
+        return fetchFail(ac.signal.reason, proceed);
       }
       const bf2 = p;
       const vl = this.#valList[index];
@@ -10164,16 +10165,16 @@ var LRUCache = class _LRUCache {
         options.status.fetchRejected = true;
         options.status.fetchError = er;
       }
-      return fetchFail(er);
+      return fetchFail(er, false);
     };
-    const fetchFail = (er) => {
+    const fetchFail = (er, proceed) => {
       const { aborted } = ac.signal;
       const allowStaleAborted = aborted && options.allowStaleOnFetchAbort;
       const allowStale = allowStaleAborted || options.allowStaleOnFetchRejection;
       const noDelete = allowStale || options.noDeleteOnFetchRejection;
       const bf2 = p;
       if (this.#valList[index] === p) {
-        const del = !noDelete || bf2.__staleWhileFetching === void 0;
+        const del = !noDelete || !proceed && bf2.__staleWhileFetching === void 0;
         if (del) {
           this.#delete(k, "fetch");
         } else if (!allowStaleAborted) {
@@ -10507,14 +10508,14 @@ var LRUCache = class _LRUCache {
   }
 };
 
-// node_modules/path-scurry/dist/esm/index.js
+// node_modules/.pnpm/path-scurry@2.0.1/node_modules/path-scurry/dist/esm/index.js
 var import_node_path = require("node:path");
 var import_node_url = require("node:url");
 var import_fs = require("fs");
 var actualFS = __toESM(require("node:fs"), 1);
 var import_promises = require("node:fs/promises");
 
-// node_modules/minipass/dist/esm/index.js
+// node_modules/.pnpm/minipass@7.1.2/node_modules/minipass/dist/esm/index.js
 var import_node_events = require("node:events");
 var import_node_stream = __toESM(require("node:stream"), 1);
 var import_node_string_decoder = require("node:string_decoder");
@@ -11392,7 +11393,7 @@ var Minipass = class extends import_node_events.EventEmitter {
   }
 };
 
-// node_modules/path-scurry/dist/esm/index.js
+// node_modules/.pnpm/path-scurry@2.0.1/node_modules/path-scurry/dist/esm/index.js
 var realpathSync = import_fs.realpathSync.native;
 var defaultFS = {
   lstatSync: import_fs.lstatSync,
@@ -13120,7 +13121,7 @@ var PathScurryDarwin = class extends PathScurryPosix {
 var Path = process.platform === "win32" ? PathWin32 : PathPosix;
 var PathScurry = process.platform === "win32" ? PathScurryWin32 : process.platform === "darwin" ? PathScurryDarwin : PathScurryPosix;
 
-// node_modules/glob/dist/esm/pattern.js
+// node_modules/.pnpm/glob@11.1.0/node_modules/glob/dist/esm/pattern.js
 var isPatternList = (pl) => pl.length >= 1;
 var isGlobList = (gl) => gl.length >= 1;
 var Pattern = class _Pattern {
@@ -13285,7 +13286,7 @@ var Pattern = class _Pattern {
   }
 };
 
-// node_modules/glob/dist/esm/ignore.js
+// node_modules/.pnpm/glob@11.1.0/node_modules/glob/dist/esm/ignore.js
 var defaultPlatform2 = typeof process === "object" && process && typeof process.platform === "string" ? process.platform : "linux";
 var Ignore = class {
   relative;
@@ -13372,7 +13373,7 @@ var Ignore = class {
   }
 };
 
-// node_modules/glob/dist/esm/processor.js
+// node_modules/.pnpm/glob@11.1.0/node_modules/glob/dist/esm/processor.js
 var HasWalkedCache = class _HasWalkedCache {
   store;
   constructor(store = /* @__PURE__ */ new Map()) {
@@ -13593,7 +13594,7 @@ var Processor = class _Processor {
   }
 };
 
-// node_modules/glob/dist/esm/walker.js
+// node_modules/.pnpm/glob@11.1.0/node_modules/glob/dist/esm/walker.js
 var makeIgnore = (ignore, opts) => typeof ignore === "string" ? new Ignore([ignore], opts) : Array.isArray(ignore) ? new Ignore(ignore, opts) : ignore;
 var GlobUtil = class {
   path;
@@ -13920,7 +13921,7 @@ var GlobStream = class extends GlobUtil {
   }
 };
 
-// node_modules/glob/dist/esm/glob.js
+// node_modules/.pnpm/glob@11.1.0/node_modules/glob/dist/esm/glob.js
 var defaultPlatform3 = typeof process === "object" && process && typeof process.platform === "string" ? process.platform : "linux";
 var Glob = class {
   absolute;
@@ -14120,7 +14121,7 @@ var Glob = class {
   }
 };
 
-// node_modules/glob/dist/esm/has-magic.js
+// node_modules/.pnpm/glob@11.1.0/node_modules/glob/dist/esm/has-magic.js
 var hasMagic = (pattern, options = {}) => {
   if (!Array.isArray(pattern)) {
     pattern = [pattern];
@@ -14132,7 +14133,7 @@ var hasMagic = (pattern, options = {}) => {
   return false;
 };
 
-// node_modules/glob/dist/esm/index.js
+// node_modules/.pnpm/glob@11.1.0/node_modules/glob/dist/esm/index.js
 function globStreamSync(pattern, options = {}) {
   return new Glob(pattern, options).streamSync();
 }
@@ -14180,7 +14181,7 @@ var glob = Object.assign(glob_, {
 });
 glob.glob = glob;
 
-// node_modules/nano-spawn/source/context.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/context.js
 var import_node_process = __toESM(require("node:process"), 1);
 var import_node_util = require("node:util");
 var getContext = (raw) => ({
@@ -14190,7 +14191,7 @@ var getContext = (raw) => ({
 });
 var getCommandPart = (part) => /[^\w./-]/.test(part) ? `'${part.replaceAll("'", "'\\''")}'` : part;
 
-// node_modules/nano-spawn/source/options.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/options.js
 var import_node_path2 = __toESM(require("node:path"), 1);
 var import_node_url3 = require("node:url");
 var import_node_process2 = __toESM(require("node:process"), 1);
@@ -14222,12 +14223,12 @@ var addLocalPath = ({ Path: Path2 = "", PATH = Path2, ...env }, cwd) => {
 };
 var getLocalPaths = (localPaths, localPath) => localPaths.at(-1) === localPath ? localPaths : getLocalPaths([...localPaths, localPath], import_node_path2.default.resolve(localPath, ".."));
 
-// node_modules/nano-spawn/source/spawn.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/spawn.js
 var import_node_child_process = require("node:child_process");
 var import_node_events3 = require("node:events");
 var import_node_process5 = __toESM(require("node:process"), 1);
 
-// node_modules/nano-spawn/source/windows.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/windows.js
 var import_promises2 = __toESM(require("node:fs/promises"), 1);
 var import_node_path3 = __toESM(require("node:path"), 1);
 var import_node_process3 = __toESM(require("node:process"), 1);
@@ -14261,7 +14262,7 @@ var exeExtensions = [".exe", ".com"];
 var escapeArgument = (argument) => escapeFile(escapeFile(`"${argument.replaceAll(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1")}"`));
 var escapeFile = (file) => file.replaceAll(/([()\][%!^"`<>&|;, *?])/g, "^$1");
 
-// node_modules/nano-spawn/source/result.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/result.js
 var import_node_events2 = require("node:events");
 var import_node_process4 = __toESM(require("node:process"), 1);
 var getResult = async (nodeChildProcess, { input }, context) => {
@@ -14320,7 +14321,7 @@ var getOutputs = ({ state: { stdout, stderr, output }, command, start }) => ({
 });
 var getOutput = (output) => output.at(-1) === "\n" ? output.slice(0, output.at(-2) === "\r" ? -2 : -1) : output;
 
-// node_modules/nano-spawn/source/spawn.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/spawn.js
 var spawnSubprocess = async (file, commandArguments, options, context) => {
   try {
     if (["node", "node.exe"].includes(file.toLowerCase())) {
@@ -14354,7 +14355,7 @@ var bufferOutput = (stream2, { state }, streamName) => {
   }
 };
 
-// node_modules/nano-spawn/source/pipe.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/pipe.js
 var import_promises3 = require("node:stream/promises");
 var handlePipe = async (subprocesses) => {
   const [[from, to]] = await Promise.all([Promise.allSettled(subprocesses), pipeStreams(subprocesses)]);
@@ -14388,7 +14389,7 @@ var closeStdin = async (nodeChildProcess) => {
   stdin.end();
 };
 
-// node_modules/nano-spawn/source/iterable.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/iterable.js
 var readline = __toESM(require("node:readline/promises"), 1);
 var lineIterator = async function* (subprocess, { state }, streamName) {
   if (state.isIterating === false) {
@@ -14438,7 +14439,7 @@ var getNext = async (iterator) => {
   }
 };
 
-// node_modules/nano-spawn/source/index.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/index.js
 function spawn2(file, second, third, previous) {
   const [commandArguments = [], options = {}] = Array.isArray(second) ? [second, third] : [[], second];
   const context = getContext([file, ...commandArguments]);

--- a/dist/prepareSwagger.js
+++ b/dist/prepareSwagger.js
@@ -25,9 +25,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/libsodium/dist/modules/libsodium.js
+// node_modules/.pnpm/libsodium@0.7.15/node_modules/libsodium/dist/modules/libsodium.js
 var require_libsodium = __commonJS({
-  "node_modules/libsodium/dist/modules/libsodium.js"(exports2, module2) {
+  "node_modules/.pnpm/libsodium@0.7.15/node_modules/libsodium/dist/modules/libsodium.js"(exports2, module2) {
     !(function(A) {
       function I(A2) {
         "use strict";
@@ -2631,9 +2631,9 @@ var require_libsodium = __commonJS({
   }
 });
 
-// node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js
+// node_modules/.pnpm/libsodium-wrappers@0.7.15/node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js
 var require_libsodium_wrappers = __commonJS({
-  "node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js"(exports2) {
+  "node_modules/.pnpm/libsodium-wrappers@0.7.15/node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js"(exports2) {
     !(function(e) {
       function a(e2, a2) {
         "use strict";
@@ -5234,9 +5234,9 @@ var require_libsodium_wrappers = __commonJS({
   }
 });
 
-// node_modules/safe-buffer/index.js
+// node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer/index.js
 var require_safe_buffer = __commonJS({
-  "node_modules/safe-buffer/index.js"(exports2, module2) {
+  "node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer/index.js"(exports2, module2) {
     var buffer = require("buffer");
     var Buffer2 = buffer.Buffer;
     function copyProps(src, dst) {
@@ -5292,9 +5292,9 @@ var require_safe_buffer = __commonJS({
   }
 });
 
-// node_modules/jws/lib/data-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/data-stream.js
 var require_data_stream = __commonJS({
-  "node_modules/jws/lib/data-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/data-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var Stream = require("stream");
     var util = require("util");
@@ -5340,9 +5340,9 @@ var require_data_stream = __commonJS({
   }
 });
 
-// node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js
+// node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js
 var require_param_bytes_for_alg = __commonJS({
-  "node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js"(exports2, module2) {
+  "node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js"(exports2, module2) {
     "use strict";
     function getParamSize(keySize) {
       var result = (keySize / 8 | 0) + (keySize % 8 === 0 ? 0 : 1);
@@ -5364,9 +5364,9 @@ var require_param_bytes_for_alg = __commonJS({
   }
 });
 
-// node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js
+// node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js
 var require_ecdsa_sig_formatter = __commonJS({
-  "node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js"(exports2, module2) {
+  "node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js"(exports2, module2) {
     "use strict";
     var Buffer2 = require_safe_buffer().Buffer;
     var getParamBytesForAlg = require_param_bytes_for_alg();
@@ -5504,9 +5504,9 @@ var require_ecdsa_sig_formatter = __commonJS({
   }
 });
 
-// node_modules/buffer-equal-constant-time/index.js
+// node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time/index.js
 var require_buffer_equal_constant_time = __commonJS({
-  "node_modules/buffer-equal-constant-time/index.js"(exports2, module2) {
+  "node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time/index.js"(exports2, module2) {
     "use strict";
     var Buffer2 = require("buffer").Buffer;
     var SlowBuffer = require("buffer").SlowBuffer;
@@ -5538,9 +5538,9 @@ var require_buffer_equal_constant_time = __commonJS({
   }
 });
 
-// node_modules/jwa/index.js
+// node_modules/.pnpm/jwa@2.0.1/node_modules/jwa/index.js
 var require_jwa = __commonJS({
-  "node_modules/jwa/index.js"(exports2, module2) {
+  "node_modules/.pnpm/jwa@2.0.1/node_modules/jwa/index.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var crypto2 = require("crypto");
     var formatEcdsa = require_ecdsa_sig_formatter();
@@ -5749,7 +5749,7 @@ var require_jwa = __commonJS({
         es: createECDSAVerifer,
         none: createNoneVerifier
       };
-      var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/i);
+      var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/);
       if (!match)
         throw typeError(MSG_INVALID_ALGORITHM, algorithm);
       var algo = (match[1] || match[3]).toLowerCase();
@@ -5762,9 +5762,9 @@ var require_jwa = __commonJS({
   }
 });
 
-// node_modules/jws/lib/tostring.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/tostring.js
 var require_tostring = __commonJS({
-  "node_modules/jws/lib/tostring.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/tostring.js"(exports2, module2) {
     var Buffer2 = require("buffer").Buffer;
     module2.exports = function toString(obj) {
       if (typeof obj === "string")
@@ -5776,9 +5776,9 @@ var require_tostring = __commonJS({
   }
 });
 
-// node_modules/jws/lib/sign-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/sign-stream.js
 var require_sign_stream = __commonJS({
-  "node_modules/jws/lib/sign-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/sign-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var DataStream = require_data_stream();
     var jwa = require_jwa();
@@ -5805,7 +5805,12 @@ var require_sign_stream = __commonJS({
       return util.format("%s.%s", securedInput, signature);
     }
     function SignStream(opts) {
-      var secret = opts.secret || opts.privateKey || opts.key;
+      var secret = opts.secret;
+      secret = secret == null ? opts.privateKey : secret;
+      secret = secret == null ? opts.key : secret;
+      if (/^hs/i.test(opts.header.alg) === true && secret == null) {
+        throw new TypeError("secret must be a string or buffer or a KeyObject");
+      }
       var secretStream = new DataStream(secret);
       this.readable = true;
       this.header = opts.header;
@@ -5846,9 +5851,9 @@ var require_sign_stream = __commonJS({
   }
 });
 
-// node_modules/jws/lib/verify-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/verify-stream.js
 var require_verify_stream = __commonJS({
-  "node_modules/jws/lib/verify-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/verify-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var DataStream = require_data_stream();
     var jwa = require_jwa();
@@ -5917,7 +5922,12 @@ var require_verify_stream = __commonJS({
     }
     function VerifyStream(opts) {
       opts = opts || {};
-      var secretOrKey = opts.secret || opts.publicKey || opts.key;
+      var secretOrKey = opts.secret;
+      secretOrKey = secretOrKey == null ? opts.publicKey : secretOrKey;
+      secretOrKey = secretOrKey == null ? opts.key : secretOrKey;
+      if (/^hs/i.test(opts.algorithm) === true && secretOrKey == null) {
+        throw new TypeError("secret must be a string or buffer or a KeyObject");
+      }
       var secretStream = new DataStream(secretOrKey);
       this.readable = true;
       this.algorithm = opts.algorithm;
@@ -5956,9 +5966,9 @@ var require_verify_stream = __commonJS({
   }
 });
 
-// node_modules/jws/index.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/index.js
 var require_jws = __commonJS({
-  "node_modules/jws/index.js"(exports2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/index.js"(exports2) {
     var SignStream = require_sign_stream();
     var VerifyStream = require_verify_stream();
     var ALGORITHMS = [
@@ -5989,9 +5999,9 @@ var require_jws = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/decode.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/decode.js
 var require_decode = __commonJS({
-  "node_modules/jsonwebtoken/decode.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/decode.js"(exports2, module2) {
     var jws = require_jws();
     module2.exports = function(jwt, options) {
       options = options || {};
@@ -6021,9 +6031,9 @@ var require_decode = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/JsonWebTokenError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/JsonWebTokenError.js
 var require_JsonWebTokenError = __commonJS({
-  "node_modules/jsonwebtoken/lib/JsonWebTokenError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/JsonWebTokenError.js"(exports2, module2) {
     var JsonWebTokenError = function(message, error) {
       Error.call(this, message);
       if (Error.captureStackTrace) {
@@ -6039,9 +6049,9 @@ var require_JsonWebTokenError = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/NotBeforeError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/NotBeforeError.js
 var require_NotBeforeError = __commonJS({
-  "node_modules/jsonwebtoken/lib/NotBeforeError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/NotBeforeError.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var NotBeforeError = function(message, date) {
       JsonWebTokenError.call(this, message);
@@ -6054,9 +6064,9 @@ var require_NotBeforeError = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/TokenExpiredError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/TokenExpiredError.js
 var require_TokenExpiredError = __commonJS({
-  "node_modules/jsonwebtoken/lib/TokenExpiredError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/TokenExpiredError.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var TokenExpiredError = function(message, expiredAt) {
       JsonWebTokenError.call(this, message);
@@ -6069,9 +6079,9 @@ var require_TokenExpiredError = __commonJS({
   }
 });
 
-// node_modules/ms/index.js
+// node_modules/.pnpm/ms@2.1.3/node_modules/ms/index.js
 var require_ms = __commonJS({
-  "node_modules/ms/index.js"(exports2, module2) {
+  "node_modules/.pnpm/ms@2.1.3/node_modules/ms/index.js"(exports2, module2) {
     var s = 1e3;
     var m = s * 60;
     var h = m * 60;
@@ -6185,9 +6195,9 @@ var require_ms = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/timespan.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/timespan.js
 var require_timespan = __commonJS({
-  "node_modules/jsonwebtoken/lib/timespan.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/timespan.js"(exports2, module2) {
     var ms = require_ms();
     module2.exports = function(time, iat) {
       var timestamp = iat || Math.floor(Date.now() / 1e3);
@@ -6206,9 +6216,9 @@ var require_timespan = __commonJS({
   }
 });
 
-// node_modules/semver/internal/constants.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/constants.js
 var require_constants = __commonJS({
-  "node_modules/semver/internal/constants.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/constants.js"(exports2, module2) {
     "use strict";
     var SEMVER_SPEC_VERSION = "2.0.0";
     var MAX_LENGTH = 256;
@@ -6238,9 +6248,9 @@ var require_constants = __commonJS({
   }
 });
 
-// node_modules/semver/internal/debug.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/debug.js
 var require_debug = __commonJS({
-  "node_modules/semver/internal/debug.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/debug.js"(exports2, module2) {
     "use strict";
     var debug = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
     };
@@ -6248,9 +6258,9 @@ var require_debug = __commonJS({
   }
 });
 
-// node_modules/semver/internal/re.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/re.js
 var require_re = __commonJS({
-  "node_modules/semver/internal/re.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/re.js"(exports2, module2) {
     "use strict";
     var {
       MAX_SAFE_COMPONENT_LENGTH,
@@ -6336,9 +6346,9 @@ var require_re = __commonJS({
   }
 });
 
-// node_modules/semver/internal/parse-options.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/parse-options.js
 var require_parse_options = __commonJS({
-  "node_modules/semver/internal/parse-options.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/parse-options.js"(exports2, module2) {
     "use strict";
     var looseOption = Object.freeze({ loose: true });
     var emptyOpts = Object.freeze({});
@@ -6355,12 +6365,15 @@ var require_parse_options = __commonJS({
   }
 });
 
-// node_modules/semver/internal/identifiers.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/identifiers.js
 var require_identifiers = __commonJS({
-  "node_modules/semver/internal/identifiers.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/identifiers.js"(exports2, module2) {
     "use strict";
     var numeric = /^[0-9]+$/;
     var compareIdentifiers = (a, b) => {
+      if (typeof a === "number" && typeof b === "number") {
+        return a === b ? 0 : a < b ? -1 : 1;
+      }
       const anum = numeric.test(a);
       const bnum = numeric.test(b);
       if (anum && bnum) {
@@ -6377,9 +6390,9 @@ var require_identifiers = __commonJS({
   }
 });
 
-// node_modules/semver/classes/semver.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js
 var require_semver = __commonJS({
-  "node_modules/semver/classes/semver.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js"(exports2, module2) {
     "use strict";
     var debug = require_debug();
     var { MAX_LENGTH, MAX_SAFE_INTEGER } = require_constants();
@@ -6467,7 +6480,25 @@ var require_semver = __commonJS({
         if (!(other instanceof _SemVer)) {
           other = new _SemVer(other, this.options);
         }
-        return compareIdentifiers(this.major, other.major) || compareIdentifiers(this.minor, other.minor) || compareIdentifiers(this.patch, other.patch);
+        if (this.major < other.major) {
+          return -1;
+        }
+        if (this.major > other.major) {
+          return 1;
+        }
+        if (this.minor < other.minor) {
+          return -1;
+        }
+        if (this.minor > other.minor) {
+          return 1;
+        }
+        if (this.patch < other.patch) {
+          return -1;
+        }
+        if (this.patch > other.patch) {
+          return 1;
+        }
+        return 0;
       }
       comparePre(other) {
         if (!(other instanceof _SemVer)) {
@@ -6638,9 +6669,9 @@ var require_semver = __commonJS({
   }
 });
 
-// node_modules/semver/functions/parse.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/parse.js
 var require_parse = __commonJS({
-  "node_modules/semver/functions/parse.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/parse.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var parse = (version, options, throwErrors = false) => {
@@ -6660,9 +6691,9 @@ var require_parse = __commonJS({
   }
 });
 
-// node_modules/semver/functions/valid.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/valid.js
 var require_valid = __commonJS({
-  "node_modules/semver/functions/valid.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/valid.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var valid = (version, options) => {
@@ -6673,9 +6704,9 @@ var require_valid = __commonJS({
   }
 });
 
-// node_modules/semver/functions/clean.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/clean.js
 var require_clean = __commonJS({
-  "node_modules/semver/functions/clean.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/clean.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var clean = (version, options) => {
@@ -6686,9 +6717,9 @@ var require_clean = __commonJS({
   }
 });
 
-// node_modules/semver/functions/inc.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/inc.js
 var require_inc = __commonJS({
-  "node_modules/semver/functions/inc.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/inc.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var inc = (version, release, options, identifier, identifierBase) => {
@@ -6710,9 +6741,9 @@ var require_inc = __commonJS({
   }
 });
 
-// node_modules/semver/functions/diff.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/diff.js
 var require_diff = __commonJS({
-  "node_modules/semver/functions/diff.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/diff.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var diff = (version1, version2) => {
@@ -6754,9 +6785,9 @@ var require_diff = __commonJS({
   }
 });
 
-// node_modules/semver/functions/major.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/major.js
 var require_major = __commonJS({
-  "node_modules/semver/functions/major.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/major.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var major = (a, loose) => new SemVer(a, loose).major;
@@ -6764,9 +6795,9 @@ var require_major = __commonJS({
   }
 });
 
-// node_modules/semver/functions/minor.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/minor.js
 var require_minor = __commonJS({
-  "node_modules/semver/functions/minor.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/minor.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var minor = (a, loose) => new SemVer(a, loose).minor;
@@ -6774,9 +6805,9 @@ var require_minor = __commonJS({
   }
 });
 
-// node_modules/semver/functions/patch.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/patch.js
 var require_patch = __commonJS({
-  "node_modules/semver/functions/patch.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/patch.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var patch = (a, loose) => new SemVer(a, loose).patch;
@@ -6784,9 +6815,9 @@ var require_patch = __commonJS({
   }
 });
 
-// node_modules/semver/functions/prerelease.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/prerelease.js
 var require_prerelease = __commonJS({
-  "node_modules/semver/functions/prerelease.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/prerelease.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var prerelease = (version, options) => {
@@ -6797,9 +6828,9 @@ var require_prerelease = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js
 var require_compare = __commonJS({
-  "node_modules/semver/functions/compare.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var compare = (a, b, loose) => new SemVer(a, loose).compare(new SemVer(b, loose));
@@ -6807,9 +6838,9 @@ var require_compare = __commonJS({
   }
 });
 
-// node_modules/semver/functions/rcompare.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rcompare.js
 var require_rcompare = __commonJS({
-  "node_modules/semver/functions/rcompare.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rcompare.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var rcompare = (a, b, loose) => compare(b, a, loose);
@@ -6817,9 +6848,9 @@ var require_rcompare = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare-loose.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-loose.js
 var require_compare_loose = __commonJS({
-  "node_modules/semver/functions/compare-loose.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-loose.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var compareLoose = (a, b) => compare(a, b, true);
@@ -6827,9 +6858,9 @@ var require_compare_loose = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare-build.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-build.js
 var require_compare_build = __commonJS({
-  "node_modules/semver/functions/compare-build.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-build.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var compareBuild = (a, b, loose) => {
@@ -6841,9 +6872,9 @@ var require_compare_build = __commonJS({
   }
 });
 
-// node_modules/semver/functions/sort.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/sort.js
 var require_sort = __commonJS({
-  "node_modules/semver/functions/sort.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/sort.js"(exports2, module2) {
     "use strict";
     var compareBuild = require_compare_build();
     var sort = (list, loose) => list.sort((a, b) => compareBuild(a, b, loose));
@@ -6851,9 +6882,9 @@ var require_sort = __commonJS({
   }
 });
 
-// node_modules/semver/functions/rsort.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rsort.js
 var require_rsort = __commonJS({
-  "node_modules/semver/functions/rsort.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rsort.js"(exports2, module2) {
     "use strict";
     var compareBuild = require_compare_build();
     var rsort = (list, loose) => list.sort((a, b) => compareBuild(b, a, loose));
@@ -6861,9 +6892,9 @@ var require_rsort = __commonJS({
   }
 });
 
-// node_modules/semver/functions/gt.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gt.js
 var require_gt = __commonJS({
-  "node_modules/semver/functions/gt.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gt.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var gt = (a, b, loose) => compare(a, b, loose) > 0;
@@ -6871,9 +6902,9 @@ var require_gt = __commonJS({
   }
 });
 
-// node_modules/semver/functions/lt.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lt.js
 var require_lt = __commonJS({
-  "node_modules/semver/functions/lt.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lt.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var lt = (a, b, loose) => compare(a, b, loose) < 0;
@@ -6881,9 +6912,9 @@ var require_lt = __commonJS({
   }
 });
 
-// node_modules/semver/functions/eq.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/eq.js
 var require_eq = __commonJS({
-  "node_modules/semver/functions/eq.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/eq.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var eq = (a, b, loose) => compare(a, b, loose) === 0;
@@ -6891,9 +6922,9 @@ var require_eq = __commonJS({
   }
 });
 
-// node_modules/semver/functions/neq.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/neq.js
 var require_neq = __commonJS({
-  "node_modules/semver/functions/neq.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/neq.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var neq = (a, b, loose) => compare(a, b, loose) !== 0;
@@ -6901,9 +6932,9 @@ var require_neq = __commonJS({
   }
 });
 
-// node_modules/semver/functions/gte.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gte.js
 var require_gte = __commonJS({
-  "node_modules/semver/functions/gte.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gte.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var gte = (a, b, loose) => compare(a, b, loose) >= 0;
@@ -6911,9 +6942,9 @@ var require_gte = __commonJS({
   }
 });
 
-// node_modules/semver/functions/lte.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lte.js
 var require_lte = __commonJS({
-  "node_modules/semver/functions/lte.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lte.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var lte = (a, b, loose) => compare(a, b, loose) <= 0;
@@ -6921,9 +6952,9 @@ var require_lte = __commonJS({
   }
 });
 
-// node_modules/semver/functions/cmp.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/cmp.js
 var require_cmp = __commonJS({
-  "node_modules/semver/functions/cmp.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/cmp.js"(exports2, module2) {
     "use strict";
     var eq = require_eq();
     var neq = require_neq();
@@ -6971,9 +7002,9 @@ var require_cmp = __commonJS({
   }
 });
 
-// node_modules/semver/functions/coerce.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/coerce.js
 var require_coerce = __commonJS({
-  "node_modules/semver/functions/coerce.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/coerce.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var parse = require_parse();
@@ -7017,9 +7048,9 @@ var require_coerce = __commonJS({
   }
 });
 
-// node_modules/semver/internal/lrucache.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/lrucache.js
 var require_lrucache = __commonJS({
-  "node_modules/semver/internal/lrucache.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/lrucache.js"(exports2, module2) {
     "use strict";
     var LRUCache = class {
       constructor() {
@@ -7055,9 +7086,9 @@ var require_lrucache = __commonJS({
   }
 });
 
-// node_modules/semver/classes/range.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/range.js
 var require_range = __commonJS({
-  "node_modules/semver/classes/range.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/range.js"(exports2, module2) {
     "use strict";
     var SPACE_CHARACTERS = /\s+/g;
     var Range = class _Range {
@@ -7228,6 +7259,7 @@ var require_range = __commonJS({
       return result;
     };
     var parseComparator = (comp, options) => {
+      comp = comp.replace(re[t.BUILD], "");
       debug("comp", comp, options);
       comp = replaceCarets(comp, options);
       debug("caret", comp);
@@ -7431,9 +7463,9 @@ var require_range = __commonJS({
   }
 });
 
-// node_modules/semver/classes/comparator.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/comparator.js
 var require_comparator = __commonJS({
-  "node_modules/semver/classes/comparator.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/comparator.js"(exports2, module2) {
     "use strict";
     var ANY = Symbol("SemVer ANY");
     var Comparator = class _Comparator {
@@ -7544,9 +7576,9 @@ var require_comparator = __commonJS({
   }
 });
 
-// node_modules/semver/functions/satisfies.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/satisfies.js
 var require_satisfies = __commonJS({
-  "node_modules/semver/functions/satisfies.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/satisfies.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var satisfies = (version, range, options) => {
@@ -7561,9 +7593,9 @@ var require_satisfies = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/to-comparators.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/to-comparators.js
 var require_to_comparators = __commonJS({
-  "node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var toComparators = (range, options) => new Range(range, options).set.map((comp) => comp.map((c) => c.value).join(" ").trim().split(" "));
@@ -7571,9 +7603,9 @@ var require_to_comparators = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/max-satisfying.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/max-satisfying.js
 var require_max_satisfying = __commonJS({
-  "node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7600,9 +7632,9 @@ var require_max_satisfying = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/min-satisfying.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-satisfying.js
 var require_min_satisfying = __commonJS({
-  "node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7629,9 +7661,9 @@ var require_min_satisfying = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/min-version.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-version.js
 var require_min_version = __commonJS({
-  "node_modules/semver/ranges/min-version.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-version.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7688,9 +7720,9 @@ var require_min_version = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/valid.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/valid.js
 var require_valid2 = __commonJS({
-  "node_modules/semver/ranges/valid.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/valid.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var validRange = (range, options) => {
@@ -7704,9 +7736,9 @@ var require_valid2 = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/outside.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/outside.js
 var require_outside = __commonJS({
-  "node_modules/semver/ranges/outside.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/outside.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Comparator = require_comparator();
@@ -7773,9 +7805,9 @@ var require_outside = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/gtr.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/gtr.js
 var require_gtr = __commonJS({
-  "node_modules/semver/ranges/gtr.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/gtr.js"(exports2, module2) {
     "use strict";
     var outside = require_outside();
     var gtr = (version, range, options) => outside(version, range, ">", options);
@@ -7783,9 +7815,9 @@ var require_gtr = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/ltr.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/ltr.js
 var require_ltr = __commonJS({
-  "node_modules/semver/ranges/ltr.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/ltr.js"(exports2, module2) {
     "use strict";
     var outside = require_outside();
     var ltr = (version, range, options) => outside(version, range, "<", options);
@@ -7793,9 +7825,9 @@ var require_ltr = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/intersects.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/intersects.js
 var require_intersects = __commonJS({
-  "node_modules/semver/ranges/intersects.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/intersects.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var intersects = (r1, r2, options) => {
@@ -7807,9 +7839,9 @@ var require_intersects = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/simplify.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/simplify.js
 var require_simplify = __commonJS({
-  "node_modules/semver/ranges/simplify.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/simplify.js"(exports2, module2) {
     "use strict";
     var satisfies = require_satisfies();
     var compare = require_compare();
@@ -7857,9 +7889,9 @@ var require_simplify = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/subset.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/subset.js
 var require_subset = __commonJS({
-  "node_modules/semver/ranges/subset.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/subset.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var Comparator = require_comparator();
@@ -8019,9 +8051,9 @@ var require_subset = __commonJS({
   }
 });
 
-// node_modules/semver/index.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/index.js
 var require_semver2 = __commonJS({
-  "node_modules/semver/index.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/index.js"(exports2, module2) {
     "use strict";
     var internalRe = require_re();
     var constants = require_constants();
@@ -8114,25 +8146,25 @@ var require_semver2 = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js
 var require_asymmetricKeyDetailsSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, ">=15.7.0");
   }
 });
 
-// node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js
 var require_rsaPssKeyDetailsSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, ">=16.9.0");
   }
 });
 
-// node_modules/jsonwebtoken/lib/validateAsymmetricKey.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/validateAsymmetricKey.js
 var require_validateAsymmetricKey = __commonJS({
-  "node_modules/jsonwebtoken/lib/validateAsymmetricKey.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/validateAsymmetricKey.js"(exports2, module2) {
     var ASYMMETRIC_KEY_DETAILS_SUPPORTED = require_asymmetricKeyDetailsSupported();
     var RSA_PSS_KEY_DETAILS_SUPPORTED = require_rsaPssKeyDetailsSupported();
     var allowedAlgorithmsForKeys = {
@@ -8183,17 +8215,17 @@ var require_validateAsymmetricKey = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/psSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/psSupported.js
 var require_psSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/psSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/psSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, "^6.12.0 || >=8.0.0");
   }
 });
 
-// node_modules/jsonwebtoken/verify.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/verify.js
 var require_verify = __commonJS({
-  "node_modules/jsonwebtoken/verify.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/verify.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var NotBeforeError = require_NotBeforeError();
     var TokenExpiredError = require_TokenExpiredError();
@@ -8406,9 +8438,9 @@ var require_verify = __commonJS({
   }
 });
 
-// node_modules/lodash.includes/index.js
+// node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes/index.js
 var require_lodash = __commonJS({
-  "node_modules/lodash.includes/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes/index.js"(exports2, module2) {
     var INFINITY = 1 / 0;
     var MAX_SAFE_INTEGER = 9007199254740991;
     var MAX_INTEGER = 17976931348623157e292;
@@ -8590,9 +8622,9 @@ var require_lodash = __commonJS({
   }
 });
 
-// node_modules/lodash.isboolean/index.js
+// node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean/index.js
 var require_lodash2 = __commonJS({
-  "node_modules/lodash.isboolean/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean/index.js"(exports2, module2) {
     var boolTag = "[object Boolean]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8606,9 +8638,9 @@ var require_lodash2 = __commonJS({
   }
 });
 
-// node_modules/lodash.isinteger/index.js
+// node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger/index.js
 var require_lodash3 = __commonJS({
-  "node_modules/lodash.isinteger/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger/index.js"(exports2, module2) {
     var INFINITY = 1 / 0;
     var MAX_INTEGER = 17976931348623157e292;
     var NAN = 0 / 0;
@@ -8670,9 +8702,9 @@ var require_lodash3 = __commonJS({
   }
 });
 
-// node_modules/lodash.isnumber/index.js
+// node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber/index.js
 var require_lodash4 = __commonJS({
-  "node_modules/lodash.isnumber/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber/index.js"(exports2, module2) {
     var numberTag = "[object Number]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8686,9 +8718,9 @@ var require_lodash4 = __commonJS({
   }
 });
 
-// node_modules/lodash.isplainobject/index.js
+// node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject/index.js
 var require_lodash5 = __commonJS({
-  "node_modules/lodash.isplainobject/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject/index.js"(exports2, module2) {
     var objectTag = "[object Object]";
     function isHostObject(value) {
       var result = false;
@@ -8730,9 +8762,9 @@ var require_lodash5 = __commonJS({
   }
 });
 
-// node_modules/lodash.isstring/index.js
+// node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring/index.js
 var require_lodash6 = __commonJS({
-  "node_modules/lodash.isstring/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring/index.js"(exports2, module2) {
     var stringTag = "[object String]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8747,9 +8779,9 @@ var require_lodash6 = __commonJS({
   }
 });
 
-// node_modules/lodash.once/index.js
+// node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once/index.js
 var require_lodash7 = __commonJS({
-  "node_modules/lodash.once/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once/index.js"(exports2, module2) {
     var FUNC_ERROR_TEXT = "Expected a function";
     var INFINITY = 1 / 0;
     var MAX_INTEGER = 17976931348623157e292;
@@ -8828,9 +8860,9 @@ var require_lodash7 = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/sign.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/sign.js
 var require_sign = __commonJS({
-  "node_modules/jsonwebtoken/sign.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/sign.js"(exports2, module2) {
     var timespan = require_timespan();
     var PS_SUPPORTED = require_psSupported();
     var validateAsymmetricKey = require_validateAsymmetricKey();
@@ -9053,9 +9085,9 @@ var require_sign = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/index.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/index.js
 var require_jsonwebtoken = __commonJS({
-  "node_modules/jsonwebtoken/index.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/index.js"(exports2, module2) {
     module2.exports = {
       decode: require_decode(),
       verify: require_verify(),
@@ -9071,7 +9103,7 @@ var require_jsonwebtoken = __commonJS({
 var fs3 = __toESM(require("node:fs"));
 var path4 = __toESM(require("node:path"));
 
-// node_modules/nano-spawn/source/context.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/context.js
 var import_node_process = __toESM(require("node:process"), 1);
 var import_node_util = require("node:util");
 var getContext = (raw) => ({
@@ -9081,7 +9113,7 @@ var getContext = (raw) => ({
 });
 var getCommandPart = (part) => /[^\w./-]/.test(part) ? `'${part.replaceAll("'", "'\\''")}'` : part;
 
-// node_modules/nano-spawn/source/options.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/options.js
 var import_node_path = __toESM(require("node:path"), 1);
 var import_node_url = require("node:url");
 var import_node_process2 = __toESM(require("node:process"), 1);
@@ -9113,12 +9145,12 @@ var addLocalPath = ({ Path = "", PATH = Path, ...env }, cwd) => {
 };
 var getLocalPaths = (localPaths, localPath) => localPaths.at(-1) === localPath ? localPaths : getLocalPaths([...localPaths, localPath], import_node_path.default.resolve(localPath, ".."));
 
-// node_modules/nano-spawn/source/spawn.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/spawn.js
 var import_node_child_process = require("node:child_process");
 var import_node_events2 = require("node:events");
 var import_node_process5 = __toESM(require("node:process"), 1);
 
-// node_modules/nano-spawn/source/windows.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/windows.js
 var import_promises = __toESM(require("node:fs/promises"), 1);
 var import_node_path2 = __toESM(require("node:path"), 1);
 var import_node_process3 = __toESM(require("node:process"), 1);
@@ -9152,7 +9184,7 @@ var exeExtensions = [".exe", ".com"];
 var escapeArgument = (argument) => escapeFile(escapeFile(`"${argument.replaceAll(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1")}"`));
 var escapeFile = (file) => file.replaceAll(/([()\][%!^"`<>&|;, *?])/g, "^$1");
 
-// node_modules/nano-spawn/source/result.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/result.js
 var import_node_events = require("node:events");
 var import_node_process4 = __toESM(require("node:process"), 1);
 var getResult = async (nodeChildProcess, { input }, context) => {
@@ -9211,7 +9243,7 @@ var getOutputs = ({ state: { stdout, stderr, output }, command, start }) => ({
 });
 var getOutput = (output) => output.at(-1) === "\n" ? output.slice(0, output.at(-2) === "\r" ? -2 : -1) : output;
 
-// node_modules/nano-spawn/source/spawn.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/spawn.js
 var spawnSubprocess = async (file, commandArguments, options, context) => {
   try {
     if (["node", "node.exe"].includes(file.toLowerCase())) {
@@ -9245,7 +9277,7 @@ var bufferOutput = (stream, { state }, streamName) => {
   }
 };
 
-// node_modules/nano-spawn/source/pipe.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/pipe.js
 var import_promises2 = require("node:stream/promises");
 var handlePipe = async (subprocesses) => {
   const [[from, to]] = await Promise.all([Promise.allSettled(subprocesses), pipeStreams(subprocesses)]);
@@ -9279,7 +9311,7 @@ var closeStdin = async (nodeChildProcess) => {
   stdin.end();
 };
 
-// node_modules/nano-spawn/source/iterable.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/iterable.js
 var readline = __toESM(require("node:readline/promises"), 1);
 var lineIterator = async function* (subprocess, { state }, streamName) {
   if (state.isIterating === false) {
@@ -9329,7 +9361,7 @@ var getNext = async (iterator) => {
   }
 };
 
-// node_modules/nano-spawn/source/index.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/index.js
 function spawn2(file, second, third, previous) {
   const [commandArguments = [], options = {}] = Array.isArray(second) ? [second, third] : [[], second];
   const context = getContext([file, ...commandArguments]);
@@ -9349,10 +9381,10 @@ function spawn2(file, second, third, previous) {
   });
 }
 
-// node_modules/@stainless-api/github-internal/lib/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/lib/secrets.mjs
 var import_libsodium_wrappers = __toESM(require_libsodium_wrappers(), 1);
 
-// node_modules/@stainless-api/github-internal/lib/auth.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/lib/auth.mjs
 var import_jsonwebtoken = __toESM(require_jsonwebtoken(), 1);
 
 // src/compat/platform.ts

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -25,9 +25,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/libsodium/dist/modules/libsodium.js
+// node_modules/.pnpm/libsodium@0.7.15/node_modules/libsodium/dist/modules/libsodium.js
 var require_libsodium = __commonJS({
-  "node_modules/libsodium/dist/modules/libsodium.js"(exports2, module2) {
+  "node_modules/.pnpm/libsodium@0.7.15/node_modules/libsodium/dist/modules/libsodium.js"(exports2, module2) {
     !(function(A) {
       function I(A2) {
         "use strict";
@@ -2631,9 +2631,9 @@ var require_libsodium = __commonJS({
   }
 });
 
-// node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js
+// node_modules/.pnpm/libsodium-wrappers@0.7.15/node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js
 var require_libsodium_wrappers = __commonJS({
-  "node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js"(exports2) {
+  "node_modules/.pnpm/libsodium-wrappers@0.7.15/node_modules/libsodium-wrappers/dist/modules/libsodium-wrappers.js"(exports2) {
     !(function(e) {
       function a(e2, a2) {
         "use strict";
@@ -5234,9 +5234,9 @@ var require_libsodium_wrappers = __commonJS({
   }
 });
 
-// node_modules/safe-buffer/index.js
+// node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer/index.js
 var require_safe_buffer = __commonJS({
-  "node_modules/safe-buffer/index.js"(exports2, module2) {
+  "node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer/index.js"(exports2, module2) {
     var buffer = require("buffer");
     var Buffer2 = buffer.Buffer;
     function copyProps(src, dst) {
@@ -5292,9 +5292,9 @@ var require_safe_buffer = __commonJS({
   }
 });
 
-// node_modules/jws/lib/data-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/data-stream.js
 var require_data_stream = __commonJS({
-  "node_modules/jws/lib/data-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/data-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var Stream = require("stream");
     var util = require("util");
@@ -5340,9 +5340,9 @@ var require_data_stream = __commonJS({
   }
 });
 
-// node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js
+// node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js
 var require_param_bytes_for_alg = __commonJS({
-  "node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js"(exports2, module2) {
+  "node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/param-bytes-for-alg.js"(exports2, module2) {
     "use strict";
     function getParamSize(keySize) {
       var result = (keySize / 8 | 0) + (keySize % 8 === 0 ? 0 : 1);
@@ -5364,9 +5364,9 @@ var require_param_bytes_for_alg = __commonJS({
   }
 });
 
-// node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js
+// node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js
 var require_ecdsa_sig_formatter = __commonJS({
-  "node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js"(exports2, module2) {
+  "node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter/src/ecdsa-sig-formatter.js"(exports2, module2) {
     "use strict";
     var Buffer2 = require_safe_buffer().Buffer;
     var getParamBytesForAlg = require_param_bytes_for_alg();
@@ -5504,9 +5504,9 @@ var require_ecdsa_sig_formatter = __commonJS({
   }
 });
 
-// node_modules/buffer-equal-constant-time/index.js
+// node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time/index.js
 var require_buffer_equal_constant_time = __commonJS({
-  "node_modules/buffer-equal-constant-time/index.js"(exports2, module2) {
+  "node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time/index.js"(exports2, module2) {
     "use strict";
     var Buffer2 = require("buffer").Buffer;
     var SlowBuffer = require("buffer").SlowBuffer;
@@ -5538,9 +5538,9 @@ var require_buffer_equal_constant_time = __commonJS({
   }
 });
 
-// node_modules/jwa/index.js
+// node_modules/.pnpm/jwa@2.0.1/node_modules/jwa/index.js
 var require_jwa = __commonJS({
-  "node_modules/jwa/index.js"(exports2, module2) {
+  "node_modules/.pnpm/jwa@2.0.1/node_modules/jwa/index.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var crypto2 = require("crypto");
     var formatEcdsa = require_ecdsa_sig_formatter();
@@ -5749,7 +5749,7 @@ var require_jwa = __commonJS({
         es: createECDSAVerifer,
         none: createNoneVerifier
       };
-      var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/i);
+      var match = algorithm.match(/^(RS|PS|ES|HS)(256|384|512)$|^(none)$/);
       if (!match)
         throw typeError(MSG_INVALID_ALGORITHM, algorithm);
       var algo = (match[1] || match[3]).toLowerCase();
@@ -5762,9 +5762,9 @@ var require_jwa = __commonJS({
   }
 });
 
-// node_modules/jws/lib/tostring.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/tostring.js
 var require_tostring = __commonJS({
-  "node_modules/jws/lib/tostring.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/tostring.js"(exports2, module2) {
     var Buffer2 = require("buffer").Buffer;
     module2.exports = function toString(obj) {
       if (typeof obj === "string")
@@ -5776,9 +5776,9 @@ var require_tostring = __commonJS({
   }
 });
 
-// node_modules/jws/lib/sign-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/sign-stream.js
 var require_sign_stream = __commonJS({
-  "node_modules/jws/lib/sign-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/sign-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var DataStream = require_data_stream();
     var jwa = require_jwa();
@@ -5805,7 +5805,12 @@ var require_sign_stream = __commonJS({
       return util.format("%s.%s", securedInput, signature);
     }
     function SignStream(opts) {
-      var secret = opts.secret || opts.privateKey || opts.key;
+      var secret = opts.secret;
+      secret = secret == null ? opts.privateKey : secret;
+      secret = secret == null ? opts.key : secret;
+      if (/^hs/i.test(opts.header.alg) === true && secret == null) {
+        throw new TypeError("secret must be a string or buffer or a KeyObject");
+      }
       var secretStream = new DataStream(secret);
       this.readable = true;
       this.header = opts.header;
@@ -5846,9 +5851,9 @@ var require_sign_stream = __commonJS({
   }
 });
 
-// node_modules/jws/lib/verify-stream.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/verify-stream.js
 var require_verify_stream = __commonJS({
-  "node_modules/jws/lib/verify-stream.js"(exports2, module2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/lib/verify-stream.js"(exports2, module2) {
     var Buffer2 = require_safe_buffer().Buffer;
     var DataStream = require_data_stream();
     var jwa = require_jwa();
@@ -5917,7 +5922,12 @@ var require_verify_stream = __commonJS({
     }
     function VerifyStream(opts) {
       opts = opts || {};
-      var secretOrKey = opts.secret || opts.publicKey || opts.key;
+      var secretOrKey = opts.secret;
+      secretOrKey = secretOrKey == null ? opts.publicKey : secretOrKey;
+      secretOrKey = secretOrKey == null ? opts.key : secretOrKey;
+      if (/^hs/i.test(opts.algorithm) === true && secretOrKey == null) {
+        throw new TypeError("secret must be a string or buffer or a KeyObject");
+      }
       var secretStream = new DataStream(secretOrKey);
       this.readable = true;
       this.algorithm = opts.algorithm;
@@ -5956,9 +5966,9 @@ var require_verify_stream = __commonJS({
   }
 });
 
-// node_modules/jws/index.js
+// node_modules/.pnpm/jws@4.0.1/node_modules/jws/index.js
 var require_jws = __commonJS({
-  "node_modules/jws/index.js"(exports2) {
+  "node_modules/.pnpm/jws@4.0.1/node_modules/jws/index.js"(exports2) {
     var SignStream = require_sign_stream();
     var VerifyStream = require_verify_stream();
     var ALGORITHMS = [
@@ -5989,9 +5999,9 @@ var require_jws = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/decode.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/decode.js
 var require_decode = __commonJS({
-  "node_modules/jsonwebtoken/decode.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/decode.js"(exports2, module2) {
     var jws = require_jws();
     module2.exports = function(jwt, options) {
       options = options || {};
@@ -6021,9 +6031,9 @@ var require_decode = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/JsonWebTokenError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/JsonWebTokenError.js
 var require_JsonWebTokenError = __commonJS({
-  "node_modules/jsonwebtoken/lib/JsonWebTokenError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/JsonWebTokenError.js"(exports2, module2) {
     var JsonWebTokenError = function(message, error) {
       Error.call(this, message);
       if (Error.captureStackTrace) {
@@ -6039,9 +6049,9 @@ var require_JsonWebTokenError = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/NotBeforeError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/NotBeforeError.js
 var require_NotBeforeError = __commonJS({
-  "node_modules/jsonwebtoken/lib/NotBeforeError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/NotBeforeError.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var NotBeforeError = function(message, date) {
       JsonWebTokenError.call(this, message);
@@ -6054,9 +6064,9 @@ var require_NotBeforeError = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/TokenExpiredError.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/TokenExpiredError.js
 var require_TokenExpiredError = __commonJS({
-  "node_modules/jsonwebtoken/lib/TokenExpiredError.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/TokenExpiredError.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var TokenExpiredError = function(message, expiredAt) {
       JsonWebTokenError.call(this, message);
@@ -6069,9 +6079,9 @@ var require_TokenExpiredError = __commonJS({
   }
 });
 
-// node_modules/ms/index.js
+// node_modules/.pnpm/ms@2.1.3/node_modules/ms/index.js
 var require_ms = __commonJS({
-  "node_modules/ms/index.js"(exports2, module2) {
+  "node_modules/.pnpm/ms@2.1.3/node_modules/ms/index.js"(exports2, module2) {
     var s = 1e3;
     var m = s * 60;
     var h = m * 60;
@@ -6185,9 +6195,9 @@ var require_ms = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/timespan.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/timespan.js
 var require_timespan = __commonJS({
-  "node_modules/jsonwebtoken/lib/timespan.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/timespan.js"(exports2, module2) {
     var ms = require_ms();
     module2.exports = function(time, iat) {
       var timestamp = iat || Math.floor(Date.now() / 1e3);
@@ -6206,9 +6216,9 @@ var require_timespan = __commonJS({
   }
 });
 
-// node_modules/semver/internal/constants.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/constants.js
 var require_constants = __commonJS({
-  "node_modules/semver/internal/constants.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/constants.js"(exports2, module2) {
     "use strict";
     var SEMVER_SPEC_VERSION = "2.0.0";
     var MAX_LENGTH = 256;
@@ -6238,9 +6248,9 @@ var require_constants = __commonJS({
   }
 });
 
-// node_modules/semver/internal/debug.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/debug.js
 var require_debug = __commonJS({
-  "node_modules/semver/internal/debug.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/debug.js"(exports2, module2) {
     "use strict";
     var debug = typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG) ? (...args) => console.error("SEMVER", ...args) : () => {
     };
@@ -6248,9 +6258,9 @@ var require_debug = __commonJS({
   }
 });
 
-// node_modules/semver/internal/re.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/re.js
 var require_re = __commonJS({
-  "node_modules/semver/internal/re.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/re.js"(exports2, module2) {
     "use strict";
     var {
       MAX_SAFE_COMPONENT_LENGTH,
@@ -6336,9 +6346,9 @@ var require_re = __commonJS({
   }
 });
 
-// node_modules/semver/internal/parse-options.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/parse-options.js
 var require_parse_options = __commonJS({
-  "node_modules/semver/internal/parse-options.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/parse-options.js"(exports2, module2) {
     "use strict";
     var looseOption = Object.freeze({ loose: true });
     var emptyOpts = Object.freeze({});
@@ -6355,12 +6365,15 @@ var require_parse_options = __commonJS({
   }
 });
 
-// node_modules/semver/internal/identifiers.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/identifiers.js
 var require_identifiers = __commonJS({
-  "node_modules/semver/internal/identifiers.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/identifiers.js"(exports2, module2) {
     "use strict";
     var numeric = /^[0-9]+$/;
     var compareIdentifiers = (a, b) => {
+      if (typeof a === "number" && typeof b === "number") {
+        return a === b ? 0 : a < b ? -1 : 1;
+      }
       const anum = numeric.test(a);
       const bnum = numeric.test(b);
       if (anum && bnum) {
@@ -6377,9 +6390,9 @@ var require_identifiers = __commonJS({
   }
 });
 
-// node_modules/semver/classes/semver.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js
 var require_semver = __commonJS({
-  "node_modules/semver/classes/semver.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js"(exports2, module2) {
     "use strict";
     var debug = require_debug();
     var { MAX_LENGTH, MAX_SAFE_INTEGER } = require_constants();
@@ -6467,7 +6480,25 @@ var require_semver = __commonJS({
         if (!(other instanceof _SemVer)) {
           other = new _SemVer(other, this.options);
         }
-        return compareIdentifiers(this.major, other.major) || compareIdentifiers(this.minor, other.minor) || compareIdentifiers(this.patch, other.patch);
+        if (this.major < other.major) {
+          return -1;
+        }
+        if (this.major > other.major) {
+          return 1;
+        }
+        if (this.minor < other.minor) {
+          return -1;
+        }
+        if (this.minor > other.minor) {
+          return 1;
+        }
+        if (this.patch < other.patch) {
+          return -1;
+        }
+        if (this.patch > other.patch) {
+          return 1;
+        }
+        return 0;
       }
       comparePre(other) {
         if (!(other instanceof _SemVer)) {
@@ -6638,9 +6669,9 @@ var require_semver = __commonJS({
   }
 });
 
-// node_modules/semver/functions/parse.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/parse.js
 var require_parse = __commonJS({
-  "node_modules/semver/functions/parse.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/parse.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var parse = (version, options, throwErrors = false) => {
@@ -6660,9 +6691,9 @@ var require_parse = __commonJS({
   }
 });
 
-// node_modules/semver/functions/valid.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/valid.js
 var require_valid = __commonJS({
-  "node_modules/semver/functions/valid.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/valid.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var valid = (version, options) => {
@@ -6673,9 +6704,9 @@ var require_valid = __commonJS({
   }
 });
 
-// node_modules/semver/functions/clean.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/clean.js
 var require_clean = __commonJS({
-  "node_modules/semver/functions/clean.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/clean.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var clean = (version, options) => {
@@ -6686,9 +6717,9 @@ var require_clean = __commonJS({
   }
 });
 
-// node_modules/semver/functions/inc.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/inc.js
 var require_inc = __commonJS({
-  "node_modules/semver/functions/inc.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/inc.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var inc = (version, release, options, identifier, identifierBase) => {
@@ -6710,9 +6741,9 @@ var require_inc = __commonJS({
   }
 });
 
-// node_modules/semver/functions/diff.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/diff.js
 var require_diff = __commonJS({
-  "node_modules/semver/functions/diff.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/diff.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var diff = (version1, version2) => {
@@ -6754,9 +6785,9 @@ var require_diff = __commonJS({
   }
 });
 
-// node_modules/semver/functions/major.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/major.js
 var require_major = __commonJS({
-  "node_modules/semver/functions/major.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/major.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var major = (a, loose) => new SemVer(a, loose).major;
@@ -6764,9 +6795,9 @@ var require_major = __commonJS({
   }
 });
 
-// node_modules/semver/functions/minor.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/minor.js
 var require_minor = __commonJS({
-  "node_modules/semver/functions/minor.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/minor.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var minor = (a, loose) => new SemVer(a, loose).minor;
@@ -6774,9 +6805,9 @@ var require_minor = __commonJS({
   }
 });
 
-// node_modules/semver/functions/patch.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/patch.js
 var require_patch = __commonJS({
-  "node_modules/semver/functions/patch.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/patch.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var patch = (a, loose) => new SemVer(a, loose).patch;
@@ -6784,9 +6815,9 @@ var require_patch = __commonJS({
   }
 });
 
-// node_modules/semver/functions/prerelease.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/prerelease.js
 var require_prerelease = __commonJS({
-  "node_modules/semver/functions/prerelease.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/prerelease.js"(exports2, module2) {
     "use strict";
     var parse = require_parse();
     var prerelease = (version, options) => {
@@ -6797,9 +6828,9 @@ var require_prerelease = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js
 var require_compare = __commonJS({
-  "node_modules/semver/functions/compare.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var compare = (a, b, loose) => new SemVer(a, loose).compare(new SemVer(b, loose));
@@ -6807,9 +6838,9 @@ var require_compare = __commonJS({
   }
 });
 
-// node_modules/semver/functions/rcompare.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rcompare.js
 var require_rcompare = __commonJS({
-  "node_modules/semver/functions/rcompare.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rcompare.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var rcompare = (a, b, loose) => compare(b, a, loose);
@@ -6817,9 +6848,9 @@ var require_rcompare = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare-loose.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-loose.js
 var require_compare_loose = __commonJS({
-  "node_modules/semver/functions/compare-loose.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-loose.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var compareLoose = (a, b) => compare(a, b, true);
@@ -6827,9 +6858,9 @@ var require_compare_loose = __commonJS({
   }
 });
 
-// node_modules/semver/functions/compare-build.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-build.js
 var require_compare_build = __commonJS({
-  "node_modules/semver/functions/compare-build.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare-build.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var compareBuild = (a, b, loose) => {
@@ -6841,9 +6872,9 @@ var require_compare_build = __commonJS({
   }
 });
 
-// node_modules/semver/functions/sort.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/sort.js
 var require_sort = __commonJS({
-  "node_modules/semver/functions/sort.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/sort.js"(exports2, module2) {
     "use strict";
     var compareBuild = require_compare_build();
     var sort = (list, loose) => list.sort((a, b) => compareBuild(a, b, loose));
@@ -6851,9 +6882,9 @@ var require_sort = __commonJS({
   }
 });
 
-// node_modules/semver/functions/rsort.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rsort.js
 var require_rsort = __commonJS({
-  "node_modules/semver/functions/rsort.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/rsort.js"(exports2, module2) {
     "use strict";
     var compareBuild = require_compare_build();
     var rsort = (list, loose) => list.sort((a, b) => compareBuild(b, a, loose));
@@ -6861,9 +6892,9 @@ var require_rsort = __commonJS({
   }
 });
 
-// node_modules/semver/functions/gt.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gt.js
 var require_gt = __commonJS({
-  "node_modules/semver/functions/gt.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gt.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var gt = (a, b, loose) => compare(a, b, loose) > 0;
@@ -6871,9 +6902,9 @@ var require_gt = __commonJS({
   }
 });
 
-// node_modules/semver/functions/lt.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lt.js
 var require_lt = __commonJS({
-  "node_modules/semver/functions/lt.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lt.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var lt = (a, b, loose) => compare(a, b, loose) < 0;
@@ -6881,9 +6912,9 @@ var require_lt = __commonJS({
   }
 });
 
-// node_modules/semver/functions/eq.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/eq.js
 var require_eq = __commonJS({
-  "node_modules/semver/functions/eq.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/eq.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var eq = (a, b, loose) => compare(a, b, loose) === 0;
@@ -6891,9 +6922,9 @@ var require_eq = __commonJS({
   }
 });
 
-// node_modules/semver/functions/neq.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/neq.js
 var require_neq = __commonJS({
-  "node_modules/semver/functions/neq.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/neq.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var neq = (a, b, loose) => compare(a, b, loose) !== 0;
@@ -6901,9 +6932,9 @@ var require_neq = __commonJS({
   }
 });
 
-// node_modules/semver/functions/gte.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gte.js
 var require_gte = __commonJS({
-  "node_modules/semver/functions/gte.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/gte.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var gte = (a, b, loose) => compare(a, b, loose) >= 0;
@@ -6911,9 +6942,9 @@ var require_gte = __commonJS({
   }
 });
 
-// node_modules/semver/functions/lte.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lte.js
 var require_lte = __commonJS({
-  "node_modules/semver/functions/lte.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/lte.js"(exports2, module2) {
     "use strict";
     var compare = require_compare();
     var lte = (a, b, loose) => compare(a, b, loose) <= 0;
@@ -6921,9 +6952,9 @@ var require_lte = __commonJS({
   }
 });
 
-// node_modules/semver/functions/cmp.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/cmp.js
 var require_cmp = __commonJS({
-  "node_modules/semver/functions/cmp.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/cmp.js"(exports2, module2) {
     "use strict";
     var eq = require_eq();
     var neq = require_neq();
@@ -6971,9 +7002,9 @@ var require_cmp = __commonJS({
   }
 });
 
-// node_modules/semver/functions/coerce.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/coerce.js
 var require_coerce = __commonJS({
-  "node_modules/semver/functions/coerce.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/coerce.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var parse = require_parse();
@@ -7017,9 +7048,9 @@ var require_coerce = __commonJS({
   }
 });
 
-// node_modules/semver/internal/lrucache.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/lrucache.js
 var require_lrucache = __commonJS({
-  "node_modules/semver/internal/lrucache.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/internal/lrucache.js"(exports2, module2) {
     "use strict";
     var LRUCache = class {
       constructor() {
@@ -7055,9 +7086,9 @@ var require_lrucache = __commonJS({
   }
 });
 
-// node_modules/semver/classes/range.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/range.js
 var require_range = __commonJS({
-  "node_modules/semver/classes/range.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/range.js"(exports2, module2) {
     "use strict";
     var SPACE_CHARACTERS = /\s+/g;
     var Range = class _Range {
@@ -7228,6 +7259,7 @@ var require_range = __commonJS({
       return result;
     };
     var parseComparator = (comp, options) => {
+      comp = comp.replace(re[t.BUILD], "");
       debug("comp", comp, options);
       comp = replaceCarets(comp, options);
       debug("caret", comp);
@@ -7431,9 +7463,9 @@ var require_range = __commonJS({
   }
 });
 
-// node_modules/semver/classes/comparator.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/comparator.js
 var require_comparator = __commonJS({
-  "node_modules/semver/classes/comparator.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/comparator.js"(exports2, module2) {
     "use strict";
     var ANY = Symbol("SemVer ANY");
     var Comparator = class _Comparator {
@@ -7544,9 +7576,9 @@ var require_comparator = __commonJS({
   }
 });
 
-// node_modules/semver/functions/satisfies.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/satisfies.js
 var require_satisfies = __commonJS({
-  "node_modules/semver/functions/satisfies.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/satisfies.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var satisfies = (version, range, options) => {
@@ -7561,9 +7593,9 @@ var require_satisfies = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/to-comparators.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/to-comparators.js
 var require_to_comparators = __commonJS({
-  "node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/to-comparators.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var toComparators = (range, options) => new Range(range, options).set.map((comp) => comp.map((c) => c.value).join(" ").trim().split(" "));
@@ -7571,9 +7603,9 @@ var require_to_comparators = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/max-satisfying.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/max-satisfying.js
 var require_max_satisfying = __commonJS({
-  "node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/max-satisfying.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7600,9 +7632,9 @@ var require_max_satisfying = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/min-satisfying.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-satisfying.js
 var require_min_satisfying = __commonJS({
-  "node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-satisfying.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7629,9 +7661,9 @@ var require_min_satisfying = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/min-version.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-version.js
 var require_min_version = __commonJS({
-  "node_modules/semver/ranges/min-version.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/min-version.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Range = require_range();
@@ -7688,9 +7720,9 @@ var require_min_version = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/valid.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/valid.js
 var require_valid2 = __commonJS({
-  "node_modules/semver/ranges/valid.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/valid.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var validRange = (range, options) => {
@@ -7704,9 +7736,9 @@ var require_valid2 = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/outside.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/outside.js
 var require_outside = __commonJS({
-  "node_modules/semver/ranges/outside.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/outside.js"(exports2, module2) {
     "use strict";
     var SemVer = require_semver();
     var Comparator = require_comparator();
@@ -7773,9 +7805,9 @@ var require_outside = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/gtr.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/gtr.js
 var require_gtr = __commonJS({
-  "node_modules/semver/ranges/gtr.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/gtr.js"(exports2, module2) {
     "use strict";
     var outside = require_outside();
     var gtr = (version, range, options) => outside(version, range, ">", options);
@@ -7783,9 +7815,9 @@ var require_gtr = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/ltr.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/ltr.js
 var require_ltr = __commonJS({
-  "node_modules/semver/ranges/ltr.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/ltr.js"(exports2, module2) {
     "use strict";
     var outside = require_outside();
     var ltr = (version, range, options) => outside(version, range, "<", options);
@@ -7793,9 +7825,9 @@ var require_ltr = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/intersects.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/intersects.js
 var require_intersects = __commonJS({
-  "node_modules/semver/ranges/intersects.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/intersects.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var intersects = (r1, r2, options) => {
@@ -7807,9 +7839,9 @@ var require_intersects = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/simplify.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/simplify.js
 var require_simplify = __commonJS({
-  "node_modules/semver/ranges/simplify.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/simplify.js"(exports2, module2) {
     "use strict";
     var satisfies = require_satisfies();
     var compare = require_compare();
@@ -7857,9 +7889,9 @@ var require_simplify = __commonJS({
   }
 });
 
-// node_modules/semver/ranges/subset.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/subset.js
 var require_subset = __commonJS({
-  "node_modules/semver/ranges/subset.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/ranges/subset.js"(exports2, module2) {
     "use strict";
     var Range = require_range();
     var Comparator = require_comparator();
@@ -8019,9 +8051,9 @@ var require_subset = __commonJS({
   }
 });
 
-// node_modules/semver/index.js
+// node_modules/.pnpm/semver@7.7.3/node_modules/semver/index.js
 var require_semver2 = __commonJS({
-  "node_modules/semver/index.js"(exports2, module2) {
+  "node_modules/.pnpm/semver@7.7.3/node_modules/semver/index.js"(exports2, module2) {
     "use strict";
     var internalRe = require_re();
     var constants = require_constants();
@@ -8114,25 +8146,25 @@ var require_semver2 = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js
 var require_asymmetricKeyDetailsSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/asymmetricKeyDetailsSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, ">=15.7.0");
   }
 });
 
-// node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js
 var require_rsaPssKeyDetailsSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/rsaPssKeyDetailsSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, ">=16.9.0");
   }
 });
 
-// node_modules/jsonwebtoken/lib/validateAsymmetricKey.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/validateAsymmetricKey.js
 var require_validateAsymmetricKey = __commonJS({
-  "node_modules/jsonwebtoken/lib/validateAsymmetricKey.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/validateAsymmetricKey.js"(exports2, module2) {
     var ASYMMETRIC_KEY_DETAILS_SUPPORTED = require_asymmetricKeyDetailsSupported();
     var RSA_PSS_KEY_DETAILS_SUPPORTED = require_rsaPssKeyDetailsSupported();
     var allowedAlgorithmsForKeys = {
@@ -8183,17 +8215,17 @@ var require_validateAsymmetricKey = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/lib/psSupported.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/psSupported.js
 var require_psSupported = __commonJS({
-  "node_modules/jsonwebtoken/lib/psSupported.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/lib/psSupported.js"(exports2, module2) {
     var semver = require_semver2();
     module2.exports = semver.satisfies(process.version, "^6.12.0 || >=8.0.0");
   }
 });
 
-// node_modules/jsonwebtoken/verify.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/verify.js
 var require_verify = __commonJS({
-  "node_modules/jsonwebtoken/verify.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/verify.js"(exports2, module2) {
     var JsonWebTokenError = require_JsonWebTokenError();
     var NotBeforeError = require_NotBeforeError();
     var TokenExpiredError = require_TokenExpiredError();
@@ -8406,9 +8438,9 @@ var require_verify = __commonJS({
   }
 });
 
-// node_modules/lodash.includes/index.js
+// node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes/index.js
 var require_lodash = __commonJS({
-  "node_modules/lodash.includes/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes/index.js"(exports2, module2) {
     var INFINITY = 1 / 0;
     var MAX_SAFE_INTEGER = 9007199254740991;
     var MAX_INTEGER = 17976931348623157e292;
@@ -8590,9 +8622,9 @@ var require_lodash = __commonJS({
   }
 });
 
-// node_modules/lodash.isboolean/index.js
+// node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean/index.js
 var require_lodash2 = __commonJS({
-  "node_modules/lodash.isboolean/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean/index.js"(exports2, module2) {
     var boolTag = "[object Boolean]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8606,9 +8638,9 @@ var require_lodash2 = __commonJS({
   }
 });
 
-// node_modules/lodash.isinteger/index.js
+// node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger/index.js
 var require_lodash3 = __commonJS({
-  "node_modules/lodash.isinteger/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger/index.js"(exports2, module2) {
     var INFINITY = 1 / 0;
     var MAX_INTEGER = 17976931348623157e292;
     var NAN = 0 / 0;
@@ -8670,9 +8702,9 @@ var require_lodash3 = __commonJS({
   }
 });
 
-// node_modules/lodash.isnumber/index.js
+// node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber/index.js
 var require_lodash4 = __commonJS({
-  "node_modules/lodash.isnumber/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber/index.js"(exports2, module2) {
     var numberTag = "[object Number]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8686,9 +8718,9 @@ var require_lodash4 = __commonJS({
   }
 });
 
-// node_modules/lodash.isplainobject/index.js
+// node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject/index.js
 var require_lodash5 = __commonJS({
-  "node_modules/lodash.isplainobject/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject/index.js"(exports2, module2) {
     var objectTag = "[object Object]";
     function isHostObject(value) {
       var result = false;
@@ -8730,9 +8762,9 @@ var require_lodash5 = __commonJS({
   }
 });
 
-// node_modules/lodash.isstring/index.js
+// node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring/index.js
 var require_lodash6 = __commonJS({
-  "node_modules/lodash.isstring/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring/index.js"(exports2, module2) {
     var stringTag = "[object String]";
     var objectProto = Object.prototype;
     var objectToString = objectProto.toString;
@@ -8747,9 +8779,9 @@ var require_lodash6 = __commonJS({
   }
 });
 
-// node_modules/lodash.once/index.js
+// node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once/index.js
 var require_lodash7 = __commonJS({
-  "node_modules/lodash.once/index.js"(exports2, module2) {
+  "node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once/index.js"(exports2, module2) {
     var FUNC_ERROR_TEXT = "Expected a function";
     var INFINITY = 1 / 0;
     var MAX_INTEGER = 17976931348623157e292;
@@ -8828,9 +8860,9 @@ var require_lodash7 = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/sign.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/sign.js
 var require_sign = __commonJS({
-  "node_modules/jsonwebtoken/sign.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/sign.js"(exports2, module2) {
     var timespan = require_timespan();
     var PS_SUPPORTED = require_psSupported();
     var validateAsymmetricKey = require_validateAsymmetricKey();
@@ -9053,9 +9085,9 @@ var require_sign = __commonJS({
   }
 });
 
-// node_modules/jsonwebtoken/index.js
+// node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/index.js
 var require_jsonwebtoken = __commonJS({
-  "node_modules/jsonwebtoken/index.js"(exports2, module2) {
+  "node_modules/.pnpm/jsonwebtoken@9.0.3/node_modules/jsonwebtoken/index.js"(exports2, module2) {
     module2.exports = {
       decode: require_decode(),
       verify: require_verify(),
@@ -9067,9 +9099,9 @@ var require_jsonwebtoken = __commonJS({
   }
 });
 
-// node_modules/ts-dedent/dist/index.js
+// node_modules/.pnpm/ts-dedent@2.2.0/node_modules/ts-dedent/dist/index.js
 var require_dist = __commonJS({
-  "node_modules/ts-dedent/dist/index.js"(exports2) {
+  "node_modules/.pnpm/ts-dedent@2.2.0/node_modules/ts-dedent/dist/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.dedent = void 0;
@@ -9122,7 +9154,7 @@ var fs5 = __toESM(require("node:fs"));
 // src/compat/index.ts
 var fs2 = __toESM(require("node:fs"));
 
-// node_modules/@stainless-api/github-internal/core/resource.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/core/resource.mjs
 var APIResource = /* @__PURE__ */ (() => {
   class APIResource3 {
     constructor(client) {
@@ -9133,7 +9165,7 @@ var APIResource = /* @__PURE__ */ (() => {
   return APIResource3;
 })();
 
-// node_modules/@stainless-api/github-internal/internal/tslib.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/tslib.mjs
 function __classPrivateFieldSet(receiver, state, value, kind, f) {
   if (kind === "m")
     throw new TypeError("Private method is not writable");
@@ -9151,7 +9183,7 @@ function __classPrivateFieldGet(receiver, state, kind, f) {
   return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 }
 
-// node_modules/@stainless-api/github-internal/internal/errors.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/errors.mjs
 function isAbortError(err) {
   return typeof err === "object" && err !== null && // Spec-compliant fetch implementations
   ("name" in err && err.name === "AbortError" || // Expo fetch
@@ -9182,7 +9214,7 @@ var castToError = (err) => {
   return new Error(err);
 };
 
-// node_modules/@stainless-api/github-internal/core/error.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/core/error.mjs
 var GitHubError = /* @__PURE__ */ (() => {
   class GitHubError2 extends Error {
   }
@@ -9274,7 +9306,7 @@ var RateLimitError = class extends APIError {
 var InternalServerError = class extends APIError {
 };
 
-// node_modules/@stainless-api/github-internal/internal/utils/values.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/utils/values.mjs
 var startsWithSchemeRegexp = /^[a-z][a-z0-9+.-]*:/i;
 var isAbsoluteURL = (url) => {
   return startsWithSchemeRegexp.test(url);
@@ -9314,7 +9346,7 @@ var safeJSON = (text) => {
   }
 };
 
-// node_modules/@stainless-api/github-internal/internal/utils/log.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/utils/log.mjs
 var levelNumbers = {
   off: 0,
   error: 200,
@@ -9387,7 +9419,7 @@ var formatRequestDetails = (details) => {
   return details;
 };
 
-// node_modules/@stainless-api/github-internal/internal/parse.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/parse.mjs
 async function defaultParseResponse(client, props) {
   const { response, requestLogID, retryOfRequestLogID, startTime } = props;
   const body = await (async () => {
@@ -9417,7 +9449,7 @@ async function defaultParseResponse(client, props) {
   return body;
 }
 
-// node_modules/@stainless-api/github-internal/core/api-promise.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/core/api-promise.mjs
 var _APIPromise_client;
 var APIPromise = /* @__PURE__ */ (() => {
   class APIPromise3 extends Promise {
@@ -9481,7 +9513,7 @@ var APIPromise = /* @__PURE__ */ (() => {
   return APIPromise3;
 })();
 
-// node_modules/@stainless-api/github-internal/core/pagination.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/core/pagination.mjs
 var _AbstractPage_client;
 var AbstractPage = /* @__PURE__ */ (() => {
   class AbstractPage3 {
@@ -9602,7 +9634,7 @@ var HypermediaPage = class extends AbstractPage {
   }
 };
 
-// node_modules/@stainless-api/github-internal/internal/headers.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/headers.mjs
 var brand_privateNullableHeaders = /* @__PURE__ */ Symbol("brand.privateNullableHeaders");
 function* iterateHeaders(headers) {
   if (!headers)
@@ -9665,7 +9697,7 @@ var buildHeaders = (newHeaders) => {
   return { [brand_privateNullableHeaders]: true, values: targetHeaders, nulls: nullHeaders };
 };
 
-// node_modules/@stainless-api/github-internal/internal/utils/path.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/utils/path.mjs
 function encodeURIPath(str) {
   return str.replace(/[^A-Za-z0-9\-._~!$&'()*+,;=:@]+/g, encodeURIComponent);
 }
@@ -9720,7 +9752,7 @@ ${underline}`);
 };
 var path = /* @__PURE__ */ createPathTagFunction(encodeURIPath);
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/comments/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/comments/reactions.mjs
 var BaseReactions = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -9797,7 +9829,7 @@ var BaseReactions = /* @__PURE__ */ (() => {
 var Reactions = class extends BaseReactions {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/comments/comments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/comments/comments.mjs
 var BaseComments = /* @__PURE__ */ (() => {
   class BaseComments7 extends APIResource {
     /**
@@ -9992,7 +10024,7 @@ var Comments = /* @__PURE__ */ (() => {
   return Comments7;
 })();
 
-// node_modules/@stainless-api/github-internal/internal/utils/uuid.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/utils/uuid.mjs
 var uuid4 = function() {
   const { crypto: crypto2 } = globalThis;
   if (crypto2?.randomUUID) {
@@ -10004,13 +10036,13 @@ var uuid4 = function() {
   return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) => (+c ^ randomByte() & 15 >> +c / 4).toString(16));
 };
 
-// node_modules/@stainless-api/github-internal/internal/utils/sleep.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/utils/sleep.mjs
 var sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-// node_modules/@stainless-api/github-internal/version.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/version.mjs
 var VERSION = "0.15.0";
 
-// node_modules/@stainless-api/github-internal/internal/detect-platform.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/detect-platform.mjs
 function getDetectedPlatform() {
   if (typeof Deno !== "undefined" && Deno.build != null) {
     return "deno";
@@ -10136,7 +10168,7 @@ var getPlatformHeaders = () => {
   return _platformHeaders ?? (_platformHeaders = getPlatformProperties());
 };
 
-// node_modules/@stainless-api/github-internal/internal/shims.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/shims.mjs
 function getDefaultFetch() {
   if (typeof fetch !== "undefined") {
     return fetch;
@@ -10181,7 +10213,7 @@ async function CancelReadableStream(stream) {
   await cancelPromise;
 }
 
-// node_modules/@stainless-api/github-internal/internal/request-options.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/request-options.mjs
 var FallbackEncoder = ({ headers, body }) => {
   return {
     bodyHeaders: {
@@ -10191,7 +10223,7 @@ var FallbackEncoder = ({ headers, body }) => {
   };
 };
 
-// node_modules/@stainless-api/github-internal/internal/qs/formats.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/qs/formats.mjs
 var default_format = "RFC3986";
 var default_formatter = (v) => String(v);
 var formatters = {
@@ -10200,7 +10232,7 @@ var formatters = {
 };
 var RFC1738 = "RFC1738";
 
-// node_modules/@stainless-api/github-internal/internal/qs/utils.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/qs/utils.mjs
 var has = (obj, key) => (has = Object.hasOwn ?? Function.prototype.call.bind(Object.prototype.hasOwnProperty), has(obj, key));
 var hex_table = /* @__PURE__ */ (() => {
   const array = [];
@@ -10279,7 +10311,7 @@ function maybe_map(val, fn) {
   return fn(val);
 }
 
-// node_modules/@stainless-api/github-internal/internal/qs/stringify.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/qs/stringify.mjs
 var array_prefix_generators = {
   brackets(prefix) {
     return String(prefix) + "[]";
@@ -10557,7 +10589,7 @@ function stringify(object, opts = {}) {
   return joined.length > 0 ? prefix + joined : "";
 }
 
-// node_modules/@stainless-api/github-internal/internal/uploads.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/uploads.mjs
 var checkFileSupport = () => {
   if (typeof File === "undefined") {
     const { process: process7 } = globalThis;
@@ -10574,7 +10606,7 @@ function getName(value) {
 }
 var isAsyncIterable = (value) => value != null && typeof value === "object" && typeof value[Symbol.asyncIterator] === "function";
 
-// node_modules/@stainless-api/github-internal/internal/to-file.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/to-file.mjs
 var isBlobLike = (value) => value != null && typeof value === "object" && typeof value.size === "number" && typeof value.type === "string" && typeof value.text === "function" && typeof value.slice === "function" && typeof value.arrayBuffer === "function";
 var isFileLike = (value) => value != null && typeof value === "object" && typeof value.name === "string" && typeof value.lastModified === "number" && isBlobLike(value);
 var isResponseLike = (value) => value != null && typeof value === "object" && typeof value.url === "string" && typeof value.blob === "function";
@@ -10626,7 +10658,7 @@ function propsForError(value) {
   return `; props: [${props.map((p) => `"${p}"`).join(", ")}]`;
 }
 
-// node_modules/@stainless-api/github-internal/resources/advisories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/advisories.mjs
 var BaseAdvisories = /* @__PURE__ */ (() => {
   class BaseAdvisories2 extends APIResource {
     /**
@@ -10657,7 +10689,7 @@ var BaseAdvisories = /* @__PURE__ */ (() => {
 var Advisories = class extends BaseAdvisories {
 };
 
-// node_modules/@stainless-api/github-internal/resources/app-manifests.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/app-manifests.mjs
 var BaseAppManifests = /* @__PURE__ */ (() => {
   class BaseAppManifests2 extends APIResource {
     /**
@@ -10677,7 +10709,7 @@ var BaseAppManifests = /* @__PURE__ */ (() => {
 var AppManifests = class extends BaseAppManifests {
 };
 
-// node_modules/@stainless-api/github-internal/resources/applications/token.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/applications/token.mjs
 var BaseToken = /* @__PURE__ */ (() => {
   class BaseToken2 extends APIResource {
     /**
@@ -10776,7 +10808,7 @@ var BaseToken = /* @__PURE__ */ (() => {
 var Token = class extends BaseToken {
 };
 
-// node_modules/@stainless-api/github-internal/resources/applications/applications.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/applications/applications.mjs
 var BaseApplications = /* @__PURE__ */ (() => {
   class BaseApplications2 extends APIResource {
     /**
@@ -10818,7 +10850,7 @@ var Applications = /* @__PURE__ */ (() => {
   return Applications2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/apps/hook/config.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/apps/hook/config.mjs
 var BaseConfig = /* @__PURE__ */ (() => {
   class BaseConfig4 extends APIResource {
     /**
@@ -10872,7 +10904,7 @@ var BaseConfig = /* @__PURE__ */ (() => {
 var Config = class extends BaseConfig {
 };
 
-// node_modules/@stainless-api/github-internal/resources/apps/hook/deliveries.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/apps/hook/deliveries.mjs
 var BaseDeliveries = /* @__PURE__ */ (() => {
   class BaseDeliveries4 extends APIResource {
     /**
@@ -10941,7 +10973,7 @@ var BaseDeliveries = /* @__PURE__ */ (() => {
 var Deliveries = class extends BaseDeliveries {
 };
 
-// node_modules/@stainless-api/github-internal/resources/apps/hook/hook.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/apps/hook/hook.mjs
 var BaseHook = /* @__PURE__ */ (() => {
   class BaseHook2 extends APIResource {
   }
@@ -10963,7 +10995,7 @@ var Hook = /* @__PURE__ */ (() => {
   return Hook2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/apps/installations/suspended.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/apps/installations/suspended.mjs
 var BaseSuspended = /* @__PURE__ */ (() => {
   class BaseSuspended2 extends APIResource {
     /**
@@ -11016,7 +11048,7 @@ var BaseSuspended = /* @__PURE__ */ (() => {
 var Suspended = class extends BaseSuspended {
 };
 
-// node_modules/@stainless-api/github-internal/resources/apps/installations/installations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/apps/installations/installations.mjs
 var BaseInstallations = /* @__PURE__ */ (() => {
   class BaseInstallations3 extends APIResource {
     /**
@@ -11136,7 +11168,7 @@ var Installations = /* @__PURE__ */ (() => {
   return Installations3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/apps/apps.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/apps/apps.mjs
 var BaseApps = /* @__PURE__ */ (() => {
   class BaseApps3 extends APIResource {
     /**
@@ -11205,7 +11237,7 @@ var Apps = /* @__PURE__ */ (() => {
   return Apps3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/assignments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/assignments.mjs
 var BaseAssignments = /* @__PURE__ */ (() => {
   class BaseAssignments2 extends APIResource {
     /**
@@ -11237,7 +11269,7 @@ var BaseAssignments = /* @__PURE__ */ (() => {
 var Assignments = class extends BaseAssignments {
 };
 
-// node_modules/@stainless-api/github-internal/resources/classrooms.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/classrooms.mjs
 var BaseClassrooms = /* @__PURE__ */ (() => {
   class BaseClassrooms2 extends APIResource {
     /**
@@ -11269,7 +11301,7 @@ var BaseClassrooms = /* @__PURE__ */ (() => {
 var Classrooms = class extends BaseClassrooms {
 };
 
-// node_modules/@stainless-api/github-internal/resources/codes-of-conduct.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/codes-of-conduct.mjs
 var BaseCodesOfConduct = /* @__PURE__ */ (() => {
   class BaseCodesOfConduct2 extends APIResource {
     /**
@@ -11291,7 +11323,7 @@ var BaseCodesOfConduct = /* @__PURE__ */ (() => {
 var CodesOfConduct = class extends BaseCodesOfConduct {
 };
 
-// node_modules/@stainless-api/github-internal/resources/emojis.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/emojis.mjs
 var BaseEmojis = /* @__PURE__ */ (() => {
   class BaseEmojis2 extends APIResource {
     /**
@@ -11307,7 +11339,7 @@ var BaseEmojis = /* @__PURE__ */ (() => {
 var Emojis = class extends BaseEmojis {
 };
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/dependabot.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/dependabot.mjs
 var BaseDependabot = /* @__PURE__ */ (() => {
   class BaseDependabot4 extends APIResource {
     /**
@@ -11345,7 +11377,7 @@ var BaseDependabot = /* @__PURE__ */ (() => {
 var Dependabot = class extends BaseDependabot {
 };
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/secret-scanning.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/secret-scanning.mjs
 var BaseSecretScanning = /* @__PURE__ */ (() => {
   class BaseSecretScanning4 extends APIResource {
     /**
@@ -11383,7 +11415,7 @@ var BaseSecretScanning = /* @__PURE__ */ (() => {
 var SecretScanning = class extends BaseSecretScanning {
 };
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/code-security/configurations/defaults.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/code-security/configurations/defaults.mjs
 var BaseDefaults = /* @__PURE__ */ (() => {
   class BaseDefaults3 extends APIResource {
     /**
@@ -11443,7 +11475,7 @@ var BaseDefaults = /* @__PURE__ */ (() => {
 var Defaults = class extends BaseDefaults {
 };
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/code-security/configurations/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/code-security/configurations/repositories.mjs
 var BaseRepositories = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -11476,7 +11508,7 @@ var BaseRepositories = /* @__PURE__ */ (() => {
 var Repositories = class extends BaseRepositories {
 };
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/code-security/configurations/configurations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/code-security/configurations/configurations.mjs
 var BaseConfigurations = /* @__PURE__ */ (() => {
   class BaseConfigurations3 extends APIResource {
     /**
@@ -11656,7 +11688,7 @@ var Configurations = /* @__PURE__ */ (() => {
   return Configurations3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/code-security/code-security.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/code-security/code-security.mjs
 var BaseCodeSecurity = /* @__PURE__ */ (() => {
   class BaseCodeSecurity3 extends APIResource {
   }
@@ -11678,7 +11710,7 @@ var CodeSecurity = /* @__PURE__ */ (() => {
   return CodeSecurity3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/enterprises/enterprises.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/enterprises/enterprises.mjs
 var BaseEnterprises = /* @__PURE__ */ (() => {
   class BaseEnterprises2 extends APIResource {
   }
@@ -11703,7 +11735,7 @@ var Enterprises = /* @__PURE__ */ (() => {
   return Enterprises2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/events.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/events.mjs
 var BaseEvents = /* @__PURE__ */ (() => {
   class BaseEvents4 extends APIResource {
     /**
@@ -11720,7 +11752,7 @@ var BaseEvents = /* @__PURE__ */ (() => {
 var Events = class extends BaseEvents {
 };
 
-// node_modules/@stainless-api/github-internal/resources/feeds.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/feeds.mjs
 var BaseFeeds = /* @__PURE__ */ (() => {
   class BaseFeeds2 extends APIResource {
     /**
@@ -11760,7 +11792,7 @@ var BaseFeeds = /* @__PURE__ */ (() => {
 var Feeds = class extends BaseFeeds {
 };
 
-// node_modules/@stainless-api/github-internal/resources/gists/comments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/gists/comments.mjs
 var BaseComments2 = /* @__PURE__ */ (() => {
   class BaseComments7 extends APIResource {
     /**
@@ -11888,7 +11920,7 @@ var BaseComments2 = /* @__PURE__ */ (() => {
 var Comments2 = class extends BaseComments2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/gists/forks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/gists/forks.mjs
 var BaseForks = /* @__PURE__ */ (() => {
   class BaseForks3 extends APIResource {
     /**
@@ -11928,7 +11960,7 @@ var BaseForks = /* @__PURE__ */ (() => {
 var Forks = class extends BaseForks {
 };
 
-// node_modules/@stainless-api/github-internal/resources/gists/star.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/gists/star.mjs
 var BaseStar = /* @__PURE__ */ (() => {
   class BaseStar2 extends APIResource {
     /**
@@ -11982,7 +12014,7 @@ var BaseStar = /* @__PURE__ */ (() => {
 var Star = class extends BaseStar {
 };
 
-// node_modules/@stainless-api/github-internal/resources/gists/gists.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/gists/gists.mjs
 var BaseGists = /* @__PURE__ */ (() => {
   class BaseGists2 extends APIResource {
     /**
@@ -12184,7 +12216,7 @@ var Gists = /* @__PURE__ */ (() => {
   return Gists2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/gitignore/templates.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/gitignore/templates.mjs
 var BaseTemplates = /* @__PURE__ */ (() => {
   class BaseTemplates2 extends APIResource {
     /**
@@ -12216,7 +12248,7 @@ var BaseTemplates = /* @__PURE__ */ (() => {
 var Templates = class extends BaseTemplates {
 };
 
-// node_modules/@stainless-api/github-internal/resources/gitignore/gitignore.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/gitignore/gitignore.mjs
 var BaseGitignore = /* @__PURE__ */ (() => {
   class BaseGitignore2 extends APIResource {
   }
@@ -12235,7 +12267,7 @@ var Gitignore = /* @__PURE__ */ (() => {
   return Gitignore2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/installation.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/installation.mjs
 var BaseInstallation = /* @__PURE__ */ (() => {
   class BaseInstallation2 extends APIResource {
     /**
@@ -12267,7 +12299,7 @@ var BaseInstallation = /* @__PURE__ */ (() => {
 var Installation = class extends BaseInstallation {
 };
 
-// node_modules/@stainless-api/github-internal/resources/issues.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/issues.mjs
 var BaseIssues = /* @__PURE__ */ (() => {
   class BaseIssues3 extends APIResource {
     /**
@@ -12309,7 +12341,7 @@ var BaseIssues = /* @__PURE__ */ (() => {
 var Issues = class extends BaseIssues {
 };
 
-// node_modules/@stainless-api/github-internal/resources/licenses.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/licenses.mjs
 var BaseLicenses = /* @__PURE__ */ (() => {
   class BaseLicenses2 extends APIResource {
     /**
@@ -12333,7 +12365,7 @@ var BaseLicenses = /* @__PURE__ */ (() => {
 var Licenses = class extends BaseLicenses {
 };
 
-// node_modules/@stainless-api/github-internal/resources/markdown.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/markdown.mjs
 var BaseMarkdown = /* @__PURE__ */ (() => {
   class BaseMarkdown2 extends APIResource {
     /**
@@ -12382,7 +12414,7 @@ var BaseMarkdown = /* @__PURE__ */ (() => {
 var Markdown = class extends BaseMarkdown {
 };
 
-// node_modules/@stainless-api/github-internal/resources/marketplace-listing/stubbed.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/marketplace-listing/stubbed.mjs
 var BaseStubbed = /* @__PURE__ */ (() => {
   class BaseStubbed2 extends APIResource {
     /**
@@ -12438,7 +12470,7 @@ var BaseStubbed = /* @__PURE__ */ (() => {
 var Stubbed = class extends BaseStubbed {
 };
 
-// node_modules/@stainless-api/github-internal/resources/marketplace-listing/marketplace-listing.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/marketplace-listing/marketplace-listing.mjs
 var BaseMarketplaceListing = /* @__PURE__ */ (() => {
   class BaseMarketplaceListing2 extends APIResource {
     /**
@@ -12505,7 +12537,7 @@ var MarketplaceListing = /* @__PURE__ */ (() => {
   return MarketplaceListing2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/meta.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/meta.mjs
 var BaseMeta = /* @__PURE__ */ (() => {
   class BaseMeta2 extends APIResource {
     /**
@@ -12532,7 +12564,7 @@ var BaseMeta = /* @__PURE__ */ (() => {
 var Meta = class extends BaseMeta {
 };
 
-// node_modules/@stainless-api/github-internal/resources/networks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/networks.mjs
 var BaseNetworks = /* @__PURE__ */ (() => {
   class BaseNetworks2 extends APIResource {
     /**
@@ -12550,7 +12582,7 @@ var BaseNetworks = /* @__PURE__ */ (() => {
 var Networks = class extends BaseNetworks {
 };
 
-// node_modules/@stainless-api/github-internal/resources/notifications/threads/subscription.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/notifications/threads/subscription.mjs
 var BaseSubscription = /* @__PURE__ */ (() => {
   class BaseSubscription3 extends APIResource {
     /**
@@ -12625,7 +12657,7 @@ var BaseSubscription = /* @__PURE__ */ (() => {
 var Subscription = class extends BaseSubscription {
 };
 
-// node_modules/@stainless-api/github-internal/resources/notifications/threads/threads.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/notifications/threads/threads.mjs
 var BaseThreads = /* @__PURE__ */ (() => {
   class BaseThreads2 extends APIResource {
     /**
@@ -12692,7 +12724,7 @@ var Threads = /* @__PURE__ */ (() => {
   return Threads2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/notifications/notifications.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/notifications/notifications.mjs
 var BaseNotifications = /* @__PURE__ */ (() => {
   class BaseNotifications3 extends APIResource {
     /**
@@ -12748,7 +12780,7 @@ var Notifications = /* @__PURE__ */ (() => {
   return Notifications3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/octocat.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/octocat.mjs
 var BaseOctocat = /* @__PURE__ */ (() => {
   class BaseOctocat2 extends APIResource {
     /**
@@ -12769,7 +12801,7 @@ var BaseOctocat = /* @__PURE__ */ (() => {
 var Octocat = class extends BaseOctocat {
 };
 
-// node_modules/@stainless-api/github-internal/resources/organizations/settings/billing.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/organizations/settings/billing.mjs
 var BaseBilling = /* @__PURE__ */ (() => {
   class BaseBilling5 extends APIResource {
     /**
@@ -12795,7 +12827,7 @@ var BaseBilling = /* @__PURE__ */ (() => {
 var Billing = class extends BaseBilling {
 };
 
-// node_modules/@stainless-api/github-internal/resources/organizations/settings/settings.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/organizations/settings/settings.mjs
 var BaseSettings = /* @__PURE__ */ (() => {
   class BaseSettings4 extends APIResource {
   }
@@ -12817,7 +12849,7 @@ var Settings = /* @__PURE__ */ (() => {
   return Settings4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/organizations/organizations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/organizations/organizations.mjs
 var BaseOrganizations = /* @__PURE__ */ (() => {
   class BaseOrganizations2 extends APIResource {
     /**
@@ -12846,7 +12878,7 @@ var Organizations = /* @__PURE__ */ (() => {
   return Organizations2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/blocks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/blocks.mjs
 var BaseBlocks = /* @__PURE__ */ (() => {
   class BaseBlocks3 extends APIResource {
     /**
@@ -12925,7 +12957,7 @@ var BaseBlocks = /* @__PURE__ */ (() => {
 var Blocks = class extends BaseBlocks {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/code-scanning.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/code-scanning.mjs
 var BaseCodeScanning = /* @__PURE__ */ (() => {
   class BaseCodeScanning3 extends APIResource {
     /**
@@ -12965,7 +12997,7 @@ var BaseCodeScanning = /* @__PURE__ */ (() => {
 var CodeScanning = class extends BaseCodeScanning {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/docker.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/docker.mjs
 var BaseDocker = /* @__PURE__ */ (() => {
   class BaseDocker3 extends APIResource {
     /**
@@ -12991,7 +13023,7 @@ var BaseDocker = /* @__PURE__ */ (() => {
 var Docker = class extends BaseDocker {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/interaction-limits.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/interaction-limits.mjs
 var BaseInteractionLimits = /* @__PURE__ */ (() => {
   class BaseInteractionLimits4 extends APIResource {
     /**
@@ -13056,7 +13088,7 @@ var BaseInteractionLimits = /* @__PURE__ */ (() => {
 var InteractionLimits = class extends BaseInteractionLimits {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/invitations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/invitations.mjs
 var BaseInvitations = /* @__PURE__ */ (() => {
   class BaseInvitations3 extends APIResource {
     /**
@@ -13154,7 +13186,7 @@ var BaseInvitations = /* @__PURE__ */ (() => {
 var Invitations = class extends BaseInvitations {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/memberships.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/memberships.mjs
 var BaseMemberships = /* @__PURE__ */ (() => {
   class BaseMemberships4 extends APIResource {
     /**
@@ -13246,7 +13278,7 @@ var BaseMemberships = /* @__PURE__ */ (() => {
 var Memberships = class extends BaseMemberships {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/outside-collaborators.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/outside-collaborators.mjs
 var BaseOutsideCollaborators = /* @__PURE__ */ (() => {
   class BaseOutsideCollaborators2 extends APIResource {
     /**
@@ -13316,7 +13348,7 @@ var BaseOutsideCollaborators = /* @__PURE__ */ (() => {
 var OutsideCollaborators = class extends BaseOutsideCollaborators {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/personal-access-token-requests.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/personal-access-token-requests.mjs
 var BasePersonalAccessTokenRequests = /* @__PURE__ */ (() => {
   class BasePersonalAccessTokenRequests2 extends APIResource {
     /**
@@ -13418,7 +13450,7 @@ var BasePersonalAccessTokenRequests = /* @__PURE__ */ (() => {
 var PersonalAccessTokenRequests = class extends BasePersonalAccessTokenRequests {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/personal-access-tokens.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/personal-access-tokens.mjs
 var BasePersonalAccessTokens = /* @__PURE__ */ (() => {
   class BasePersonalAccessTokens2 extends APIResource {
     /**
@@ -13512,7 +13544,7 @@ var BasePersonalAccessTokens = /* @__PURE__ */ (() => {
 var PersonalAccessTokens = class extends BasePersonalAccessTokens {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/private-registries.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/private-registries.mjs
 var BasePrivateRegistries = /* @__PURE__ */ (() => {
   class BasePrivateRegistries2 extends APIResource {
     /**
@@ -13651,7 +13683,7 @@ var BasePrivateRegistries = /* @__PURE__ */ (() => {
 var PrivateRegistries = class extends BasePrivateRegistries {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/public-members.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/public-members.mjs
 var BasePublicMembers = /* @__PURE__ */ (() => {
   class BasePublicMembers2 extends APIResource {
     /**
@@ -13741,7 +13773,7 @@ var BasePublicMembers = /* @__PURE__ */ (() => {
 var PublicMembers = class extends BasePublicMembers {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/secret-scanning.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/secret-scanning.mjs
 var BaseSecretScanning2 = /* @__PURE__ */ (() => {
   class BaseSecretScanning4 extends APIResource {
     /**
@@ -13778,7 +13810,7 @@ var BaseSecretScanning2 = /* @__PURE__ */ (() => {
 var SecretScanning2 = class extends BaseSecretScanning2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/cache.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/cache.mjs
 var BaseCache = /* @__PURE__ */ (() => {
   class BaseCache3 extends APIResource {
     /**
@@ -13828,7 +13860,7 @@ var BaseCache = /* @__PURE__ */ (() => {
 var Cache = class extends BaseCache {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/hosted-runners/images.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/hosted-runners/images.mjs
 var BaseImages = /* @__PURE__ */ (() => {
   class BaseImages2 extends APIResource {
     /**
@@ -13873,7 +13905,7 @@ var BaseImages = /* @__PURE__ */ (() => {
 var Images = class extends BaseImages {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/hosted-runners/hosted-runners.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/hosted-runners/hosted-runners.mjs
 var BaseHostedRunners = /* @__PURE__ */ (() => {
   class BaseHostedRunners2 extends APIResource {
     /**
@@ -14031,7 +14063,7 @@ var HostedRunners = /* @__PURE__ */ (() => {
   return HostedRunners2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/oidc/customization/sub.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/oidc/customization/sub.mjs
 var BaseSub = /* @__PURE__ */ (() => {
   class BaseSub3 extends APIResource {
     /**
@@ -14077,7 +14109,7 @@ var BaseSub = /* @__PURE__ */ (() => {
 var Sub = class extends BaseSub {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/oidc/customization/customization.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/oidc/customization/customization.mjs
 var BaseCustomization = /* @__PURE__ */ (() => {
   class BaseCustomization3 extends APIResource {
   }
@@ -14101,7 +14133,7 @@ var Customization = /* @__PURE__ */ (() => {
   return Customization3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/oidc/oidc.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/oidc/oidc.mjs
 var BaseOidc = /* @__PURE__ */ (() => {
   class BaseOidc3 extends APIResource {
   }
@@ -14124,7 +14156,7 @@ var Oidc = /* @__PURE__ */ (() => {
   return Oidc3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/repositories.mjs
 var BaseRepositories2 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -14235,7 +14267,7 @@ var BaseRepositories2 = /* @__PURE__ */ (() => {
 var Repositories2 = class extends BaseRepositories2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/selected-actions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/selected-actions.mjs
 var BaseSelectedActions = /* @__PURE__ */ (() => {
   class BaseSelectedActions3 extends APIResource {
     /**
@@ -14292,7 +14324,7 @@ var BaseSelectedActions = /* @__PURE__ */ (() => {
 var SelectedActions = class extends BaseSelectedActions {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/workflow.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/workflow.mjs
 var BaseWorkflow = /* @__PURE__ */ (() => {
   class BaseWorkflow3 extends APIResource {
     /**
@@ -14354,7 +14386,7 @@ var BaseWorkflow = /* @__PURE__ */ (() => {
 var Workflow = class extends BaseWorkflow {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/permissions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/permissions/permissions.mjs
 var BasePermissions = /* @__PURE__ */ (() => {
   class BasePermissions3 extends APIResource {
     /**
@@ -14421,7 +14453,7 @@ var Permissions = /* @__PURE__ */ (() => {
   return Permissions3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/runner-groups/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/runner-groups/repositories.mjs
 var BaseRepositories3 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -14519,7 +14551,7 @@ var BaseRepositories3 = /* @__PURE__ */ (() => {
 var Repositories3 = class extends BaseRepositories3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/runner-groups/runners.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/runner-groups/runners.mjs
 var BaseRunners = /* @__PURE__ */ (() => {
   class BaseRunners4 extends APIResource {
     /**
@@ -14618,7 +14650,7 @@ var BaseRunners = /* @__PURE__ */ (() => {
 var Runners = class extends BaseRunners {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/runner-groups/runner-groups.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/runner-groups/runner-groups.mjs
 var BaseRunnerGroups = /* @__PURE__ */ (() => {
   class BaseRunnerGroups2 extends APIResource {
     /**
@@ -14764,7 +14796,7 @@ var RunnerGroups = /* @__PURE__ */ (() => {
   return RunnerGroups2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/runners/labels.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/runners/labels.mjs
 var BaseLabels = /* @__PURE__ */ (() => {
   class BaseLabels5 extends APIResource {
     /**
@@ -14897,7 +14929,7 @@ var BaseLabels = /* @__PURE__ */ (() => {
 var Labels = class extends BaseLabels {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/runners/runners.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/runners/runners.mjs
 var BaseRunners2 = /* @__PURE__ */ (() => {
   class BaseRunners4 extends APIResource {
     /**
@@ -15092,7 +15124,7 @@ var Runners2 = /* @__PURE__ */ (() => {
   return Runners4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/secrets/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/secrets/repositories.mjs
 var BaseRepositories4 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -15214,7 +15246,7 @@ var BaseRepositories4 = /* @__PURE__ */ (() => {
 var Repositories4 = class extends BaseRepositories4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/secrets/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/secrets/secrets.mjs
 var BaseSecrets = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -15359,7 +15391,7 @@ var Secrets = /* @__PURE__ */ (() => {
   return Secrets9;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/variables/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/variables/repositories.mjs
 var BaseRepositories5 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -15480,7 +15512,7 @@ var BaseRepositories5 = /* @__PURE__ */ (() => {
 var Repositories5 = class extends BaseRepositories5 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/variables/variables.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/variables/variables.mjs
 var BaseVariables = /* @__PURE__ */ (() => {
   class BaseVariables4 extends APIResource {
     /**
@@ -15626,7 +15658,7 @@ var Variables = /* @__PURE__ */ (() => {
   return Variables4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/actions/actions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/actions/actions.mjs
 var BaseActions = /* @__PURE__ */ (() => {
   class BaseActions3 extends APIResource {
   }
@@ -15666,7 +15698,7 @@ var Actions = /* @__PURE__ */ (() => {
   return Actions3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/code-security/configurations/defaults.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/code-security/configurations/defaults.mjs
 var BaseDefaults2 = /* @__PURE__ */ (() => {
   class BaseDefaults3 extends APIResource {
     /**
@@ -15725,7 +15757,7 @@ var BaseDefaults2 = /* @__PURE__ */ (() => {
 var Defaults2 = class extends BaseDefaults2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/code-security/configurations/configurations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/code-security/configurations/configurations.mjs
 var BaseConfigurations2 = /* @__PURE__ */ (() => {
   class BaseConfigurations3 extends APIResource {
     /**
@@ -15952,7 +15984,7 @@ var Configurations2 = /* @__PURE__ */ (() => {
   return Configurations3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/code-security/code-security.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/code-security/code-security.mjs
 var BaseCodeSecurity2 = /* @__PURE__ */ (() => {
   class BaseCodeSecurity3 extends APIResource {
   }
@@ -15974,7 +16006,7 @@ var CodeSecurity2 = /* @__PURE__ */ (() => {
   return CodeSecurity3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/codespaces/secrets/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/codespaces/secrets/repositories.mjs
 var BaseRepositories6 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -16078,7 +16110,7 @@ var BaseRepositories6 = /* @__PURE__ */ (() => {
 var Repositories6 = class extends BaseRepositories6 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/codespaces/secrets/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/codespaces/secrets/secrets.mjs
 var BaseSecrets2 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -16201,7 +16233,7 @@ var Secrets2 = /* @__PURE__ */ (() => {
   return Secrets9;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/codespaces/codespaces.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/codespaces/codespaces.mjs
 var BaseCodespaces = /* @__PURE__ */ (() => {
   class BaseCodespaces5 extends APIResource {
     /**
@@ -16237,7 +16269,7 @@ var Codespaces = /* @__PURE__ */ (() => {
   return Codespaces5;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/copilot/billing/selected-teams.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/copilot/billing/selected-teams.mjs
 var BaseSelectedTeams = /* @__PURE__ */ (() => {
   class BaseSelectedTeams2 extends APIResource {
     /**
@@ -16320,7 +16352,7 @@ var BaseSelectedTeams = /* @__PURE__ */ (() => {
 var SelectedTeams = class extends BaseSelectedTeams {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/copilot/billing/selected-users.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/copilot/billing/selected-users.mjs
 var BaseSelectedUsers = /* @__PURE__ */ (() => {
   class BaseSelectedUsers2 extends APIResource {
     /**
@@ -16410,7 +16442,7 @@ var BaseSelectedUsers = /* @__PURE__ */ (() => {
 var SelectedUsers = class extends BaseSelectedUsers {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/copilot/billing/billing.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/copilot/billing/billing.mjs
 var BaseBilling2 = /* @__PURE__ */ (() => {
   class BaseBilling5 extends APIResource {
     /**
@@ -16485,7 +16517,7 @@ var Billing2 = /* @__PURE__ */ (() => {
   return Billing5;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/copilot/copilot.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/copilot/copilot.mjs
 var BaseCopilot = /* @__PURE__ */ (() => {
   class BaseCopilot3 extends APIResource {
     /**
@@ -16535,7 +16567,7 @@ var Copilot = /* @__PURE__ */ (() => {
   return Copilot3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/dependabot/secrets/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/dependabot/secrets/repositories.mjs
 var BaseRepositories7 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -16637,7 +16669,7 @@ var BaseRepositories7 = /* @__PURE__ */ (() => {
 var Repositories7 = class extends BaseRepositories7 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/dependabot/secrets/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/dependabot/secrets/secrets.mjs
 var BaseSecrets3 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -16761,7 +16793,7 @@ var Secrets3 = /* @__PURE__ */ (() => {
   return Secrets9;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/dependabot/dependabot.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/dependabot/dependabot.mjs
 var BaseDependabot2 = /* @__PURE__ */ (() => {
   class BaseDependabot4 extends APIResource {
     /**
@@ -16803,7 +16835,7 @@ var Dependabot2 = /* @__PURE__ */ (() => {
   return Dependabot4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/hooks/config.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/hooks/config.mjs
 var BaseConfig2 = /* @__PURE__ */ (() => {
   class BaseConfig4 extends APIResource {
     /**
@@ -16867,7 +16899,7 @@ var BaseConfig2 = /* @__PURE__ */ (() => {
 var Config2 = class extends BaseConfig2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/hooks/deliveries.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/hooks/deliveries.mjs
 var BaseDeliveries2 = /* @__PURE__ */ (() => {
   class BaseDeliveries4 extends APIResource {
     /**
@@ -16950,7 +16982,7 @@ var BaseDeliveries2 = /* @__PURE__ */ (() => {
 var Deliveries2 = class extends BaseDeliveries2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/hooks/hooks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/hooks/hooks.mjs
 var BaseHooks = /* @__PURE__ */ (() => {
   class BaseHooks3 extends APIResource {
     /**
@@ -17117,7 +17149,7 @@ var Hooks = /* @__PURE__ */ (() => {
   return Hooks3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/insights/api/summary-stats.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/insights/api/summary-stats.mjs
 var BaseSummaryStats = /* @__PURE__ */ (() => {
   class BaseSummaryStats2 extends APIResource {
     /**
@@ -17192,7 +17224,7 @@ var BaseSummaryStats = /* @__PURE__ */ (() => {
 var SummaryStats = class extends BaseSummaryStats {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/insights/api/time-stats.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/insights/api/time-stats.mjs
 var BaseTimeStats = /* @__PURE__ */ (() => {
   class BaseTimeStats2 extends APIResource {
     /**
@@ -17275,7 +17307,7 @@ var BaseTimeStats = /* @__PURE__ */ (() => {
 var TimeStats = class extends BaseTimeStats {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/insights/api/api.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/insights/api/api.mjs
 var BaseAPI = /* @__PURE__ */ (() => {
   class BaseAPI2 extends APIResource {
     /**
@@ -17354,7 +17386,7 @@ var API = /* @__PURE__ */ (() => {
   return API2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/insights/insights.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/insights/insights.mjs
 var BaseInsights = /* @__PURE__ */ (() => {
   class BaseInsights2 extends APIResource {
   }
@@ -17373,7 +17405,7 @@ var Insights = /* @__PURE__ */ (() => {
   return Insights2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/members/codespaces.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/members/codespaces.mjs
 var BaseCodespaces2 = /* @__PURE__ */ (() => {
   class BaseCodespaces5 extends APIResource {
     /**
@@ -17443,7 +17475,7 @@ var BaseCodespaces2 = /* @__PURE__ */ (() => {
 var Codespaces2 = class extends BaseCodespaces2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/members/members.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/members/members.mjs
 var BaseMembers = /* @__PURE__ */ (() => {
   class BaseMembers2 extends APIResource {
     /**
@@ -17553,7 +17585,7 @@ var Members = /* @__PURE__ */ (() => {
   return Members2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/migrations/archive.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/migrations/archive.mjs
 var BaseArchive = /* @__PURE__ */ (() => {
   class BaseArchive3 extends APIResource {
     /**
@@ -17602,7 +17634,7 @@ var BaseArchive = /* @__PURE__ */ (() => {
 var Archive = class extends BaseArchive {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/migrations/repos.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/migrations/repos.mjs
 var BaseRepos = /* @__PURE__ */ (() => {
   class BaseRepos6 extends APIResource {
     /**
@@ -17637,7 +17669,7 @@ var BaseRepos = /* @__PURE__ */ (() => {
 var Repos = class extends BaseRepos {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/migrations/migrations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/migrations/migrations.mjs
 var BaseMigrations = /* @__PURE__ */ (() => {
   class BaseMigrations3 extends APIResource {
     /**
@@ -17740,7 +17772,7 @@ var Migrations = /* @__PURE__ */ (() => {
   return Migrations3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/organization-roles/teams.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/organization-roles/teams.mjs
 var BaseTeams = /* @__PURE__ */ (() => {
   class BaseTeams5 extends APIResource {
     /**
@@ -17857,7 +17889,7 @@ var BaseTeams = /* @__PURE__ */ (() => {
 var Teams = class extends BaseTeams {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/organization-roles/users.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/organization-roles/users.mjs
 var BaseUsers = /* @__PURE__ */ (() => {
   class BaseUsers4 extends APIResource {
     /**
@@ -17974,7 +18006,7 @@ var BaseUsers = /* @__PURE__ */ (() => {
 var Users = class extends BaseUsers {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/organization-roles/organization-roles.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/organization-roles/organization-roles.mjs
 var BaseOrganizationRoles = /* @__PURE__ */ (() => {
   class BaseOrganizationRoles2 extends APIResource {
     /**
@@ -18048,7 +18080,7 @@ var OrganizationRoles = /* @__PURE__ */ (() => {
   return OrganizationRoles2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/packages/versions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/packages/versions.mjs
 var BaseVersions = /* @__PURE__ */ (() => {
   class BaseVersions4 extends APIResource {
     /**
@@ -18169,7 +18201,7 @@ var BaseVersions = /* @__PURE__ */ (() => {
 var Versions = class extends BaseVersions {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/packages/packages.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/packages/packages.mjs
 var BasePackages = /* @__PURE__ */ (() => {
   class BasePackages3 extends APIResource {
     /**
@@ -18299,7 +18331,7 @@ var Packages = /* @__PURE__ */ (() => {
   return Packages3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/properties/schema.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/properties/schema.mjs
 var BaseSchema = /* @__PURE__ */ (() => {
   class BaseSchema2 extends APIResource {
     /**
@@ -18442,7 +18474,7 @@ var BaseSchema = /* @__PURE__ */ (() => {
 var Schema = class extends BaseSchema {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/properties/values.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/properties/values.mjs
 var BaseValues = /* @__PURE__ */ (() => {
   class BaseValues3 extends APIResource {
     /**
@@ -18511,7 +18543,7 @@ var BaseValues = /* @__PURE__ */ (() => {
 var Values = class extends BaseValues {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/properties/properties.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/properties/properties.mjs
 var BaseProperties = /* @__PURE__ */ (() => {
   class BaseProperties3 extends APIResource {
   }
@@ -18536,7 +18568,7 @@ var Properties = /* @__PURE__ */ (() => {
   return Properties3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/rulesets/history.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/rulesets/history.mjs
 var BaseHistory = /* @__PURE__ */ (() => {
   class BaseHistory3 extends APIResource {
     /**
@@ -18583,7 +18615,7 @@ var BaseHistory = /* @__PURE__ */ (() => {
 var History = class extends BaseHistory {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/rulesets/rule-suites.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/rulesets/rule-suites.mjs
 var BaseRuleSuites = /* @__PURE__ */ (() => {
   class BaseRuleSuites3 extends APIResource {
     /**
@@ -18632,7 +18664,7 @@ var BaseRuleSuites = /* @__PURE__ */ (() => {
 var RuleSuites = class extends BaseRuleSuites {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/rulesets/rulesets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/rulesets/rulesets.mjs
 var BaseRulesets = /* @__PURE__ */ (() => {
   class BaseRulesets3 extends APIResource {
     /**
@@ -18760,7 +18792,7 @@ var Rulesets = /* @__PURE__ */ (() => {
   return Rulesets3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/settings/billing.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/settings/billing.mjs
 var BaseBilling3 = /* @__PURE__ */ (() => {
   class BaseBilling5 extends APIResource {
     /**
@@ -18837,7 +18869,7 @@ var BaseBilling3 = /* @__PURE__ */ (() => {
 var Billing3 = class extends BaseBilling3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/settings/network-configurations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/settings/network-configurations.mjs
 var BaseNetworkConfigurations = /* @__PURE__ */ (() => {
   class BaseNetworkConfigurations2 extends APIResource {
     /**
@@ -18957,7 +18989,7 @@ var BaseNetworkConfigurations = /* @__PURE__ */ (() => {
 var NetworkConfigurations = class extends BaseNetworkConfigurations {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/settings/settings.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/settings/settings.mjs
 var BaseSettings2 = /* @__PURE__ */ (() => {
   class BaseSettings4 extends APIResource {
     /**
@@ -18998,7 +19030,7 @@ var Settings2 = /* @__PURE__ */ (() => {
   return Settings4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/copilot.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/copilot.mjs
 var BaseCopilot2 = /* @__PURE__ */ (() => {
   class BaseCopilot3 extends APIResource {
     /**
@@ -19046,7 +19078,7 @@ var BaseCopilot2 = /* @__PURE__ */ (() => {
 var Copilot2 = class extends BaseCopilot2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/memberships.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/memberships.mjs
 var BaseMemberships2 = /* @__PURE__ */ (() => {
   class BaseMemberships4 extends APIResource {
     /**
@@ -19174,7 +19206,7 @@ var BaseMemberships2 = /* @__PURE__ */ (() => {
 var Memberships2 = class extends BaseMemberships2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/repos.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/repos.mjs
 var BaseRepos2 = /* @__PURE__ */ (() => {
   class BaseRepos6 extends APIResource {
     /**
@@ -19302,7 +19334,7 @@ var BaseRepos2 = /* @__PURE__ */ (() => {
 var Repos2 = class extends BaseRepos2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/reactions.mjs
 var BaseReactions2 = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -19393,7 +19425,7 @@ var BaseReactions2 = /* @__PURE__ */ (() => {
 var Reactions2 = class extends BaseReactions2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/comments/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/comments/reactions.mjs
 var BaseReactions3 = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -19491,7 +19523,7 @@ var BaseReactions3 = /* @__PURE__ */ (() => {
 var Reactions3 = class extends BaseReactions3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/comments/comments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/comments/comments.mjs
 var BaseComments3 = /* @__PURE__ */ (() => {
   class BaseComments7 extends APIResource {
     /**
@@ -19642,7 +19674,7 @@ var Comments3 = /* @__PURE__ */ (() => {
   return Comments7;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/discussions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/discussions/discussions.mjs
 var BaseDiscussions = /* @__PURE__ */ (() => {
   class BaseDiscussions2 extends APIResource {
     /**
@@ -19796,7 +19828,7 @@ var Discussions = /* @__PURE__ */ (() => {
   return Discussions2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/teams/teams.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/teams/teams.mjs
 var BaseTeams2 = /* @__PURE__ */ (() => {
   class BaseTeams5 extends APIResource {
     /**
@@ -19998,7 +20030,7 @@ var Teams2 = /* @__PURE__ */ (() => {
   return Teams5;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/orgs/orgs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/orgs/orgs.mjs
 var BaseOrgs = /* @__PURE__ */ (() => {
   class BaseOrgs3 extends APIResource {
     /**
@@ -20344,7 +20376,7 @@ var Orgs = /* @__PURE__ */ (() => {
   return Orgs4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/rate-limit.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/rate-limit.mjs
 var BaseRateLimitResource = /* @__PURE__ */ (() => {
   class BaseRateLimitResource2 extends APIResource {
     /**
@@ -20402,7 +20434,7 @@ var BaseRateLimitResource = /* @__PURE__ */ (() => {
 var RateLimitResource = class extends BaseRateLimitResource {
 };
 
-// node_modules/@stainless-api/github-internal/resources/search.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/search.mjs
 var BaseSearch = /* @__PURE__ */ (() => {
   class BaseSearch2 extends APIResource {
     /**
@@ -20577,7 +20609,7 @@ var BaseSearch = /* @__PURE__ */ (() => {
 var Search = class extends BaseSearch {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/assignees.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/assignees.mjs
 var BaseAssignees = /* @__PURE__ */ (() => {
   class BaseAssignees3 extends APIResource {
     /**
@@ -20632,7 +20664,7 @@ var BaseAssignees = /* @__PURE__ */ (() => {
 var Assignees = class extends BaseAssignees {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/attestations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/attestations.mjs
 var BaseAttestations = /* @__PURE__ */ (() => {
   class BaseAttestations2 extends APIResource {
     /**
@@ -20701,7 +20733,7 @@ var BaseAttestations = /* @__PURE__ */ (() => {
 var Attestations = class extends BaseAttestations {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/autolinks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/autolinks.mjs
 var BaseAutolinks = /* @__PURE__ */ (() => {
   class BaseAutolinks2 extends APIResource {
     /**
@@ -20788,7 +20820,7 @@ var BaseAutolinks = /* @__PURE__ */ (() => {
 var Autolinks = class extends BaseAutolinks {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/automated-security-fixes.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/automated-security-fixes.mjs
 var BaseAutomatedSecurityFixes = /* @__PURE__ */ (() => {
   class BaseAutomatedSecurityFixes2 extends APIResource {
     /**
@@ -20860,7 +20892,7 @@ var BaseAutomatedSecurityFixes = /* @__PURE__ */ (() => {
 var AutomatedSecurityFixes = class extends BaseAutomatedSecurityFixes {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/check-runs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/check-runs.mjs
 var BaseCheckRuns = /* @__PURE__ */ (() => {
   class BaseCheckRuns2 extends APIResource {
     /**
@@ -21020,7 +21052,7 @@ var BaseCheckRuns = /* @__PURE__ */ (() => {
 var CheckRuns = class extends BaseCheckRuns {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/check-suites.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/check-suites.mjs
 var BaseCheckSuites = /* @__PURE__ */ (() => {
   class BaseCheckSuites2 extends APIResource {
     /**
@@ -21150,7 +21182,7 @@ var BaseCheckSuites = /* @__PURE__ */ (() => {
 var CheckSuites = class extends BaseCheckSuites {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/codeowners.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/codeowners.mjs
 var BaseCodeowners = /* @__PURE__ */ (() => {
   class BaseCodeowners2 extends APIResource {
     /**
@@ -21183,7 +21215,7 @@ var BaseCodeowners = /* @__PURE__ */ (() => {
 var Codeowners = class extends BaseCodeowners {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/collaborators.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/collaborators.mjs
 var BaseCollaborators = /* @__PURE__ */ (() => {
   class BaseCollaborators2 extends APIResource {
     /**
@@ -21406,7 +21438,7 @@ var BaseCollaborators = /* @__PURE__ */ (() => {
 var Collaborators = class extends BaseCollaborators {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/community.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/community.mjs
 var BaseCommunity = /* @__PURE__ */ (() => {
   class BaseCommunity2 extends APIResource {
     /**
@@ -21446,7 +21478,7 @@ var BaseCommunity = /* @__PURE__ */ (() => {
 var Community = class extends BaseCommunity {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/contents.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/contents.mjs
 var BaseContents = /* @__PURE__ */ (() => {
   class BaseContents2 extends APIResource {
     /**
@@ -21598,7 +21630,7 @@ var BaseContents = /* @__PURE__ */ (() => {
 var Contents = class extends BaseContents {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/contributors.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/contributors.mjs
 var BaseContributors = /* @__PURE__ */ (() => {
   class BaseContributors2 extends APIResource {
     /**
@@ -21640,7 +21672,7 @@ var BaseContributors = /* @__PURE__ */ (() => {
 var Contributors = class extends BaseContributors {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/dependency-graph.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/dependency-graph.mjs
 var BaseDependencyGraph = /* @__PURE__ */ (() => {
   class BaseDependencyGraph2 extends APIResource {
     /**
@@ -21722,7 +21754,7 @@ var BaseDependencyGraph = /* @__PURE__ */ (() => {
 var DependencyGraph = class extends BaseDependencyGraph {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/forks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/forks.mjs
 var BaseForks2 = /* @__PURE__ */ (() => {
   class BaseForks3 extends APIResource {
     /**
@@ -21776,7 +21808,7 @@ var BaseForks2 = /* @__PURE__ */ (() => {
 var Forks2 = class extends BaseForks2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/interaction-limits.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/interaction-limits.mjs
 var BaseInteractionLimits2 = /* @__PURE__ */ (() => {
   class BaseInteractionLimits4 extends APIResource {
     /**
@@ -21851,7 +21883,7 @@ var BaseInteractionLimits2 = /* @__PURE__ */ (() => {
 var InteractionLimits2 = class extends BaseInteractionLimits2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/invitations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/invitations.mjs
 var BaseInvitations2 = /* @__PURE__ */ (() => {
   class BaseInvitations3 extends APIResource {
     /**
@@ -21918,7 +21950,7 @@ var BaseInvitations2 = /* @__PURE__ */ (() => {
 var Invitations2 = class extends BaseInvitations2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/keys.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/keys.mjs
 var BaseKeys = /* @__PURE__ */ (() => {
   class BaseKeys3 extends APIResource {
     /**
@@ -22001,7 +22033,7 @@ var BaseKeys = /* @__PURE__ */ (() => {
 var Keys = class extends BaseKeys {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/labels.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/labels.mjs
 var BaseLabels2 = /* @__PURE__ */ (() => {
   class BaseLabels5 extends APIResource {
     /**
@@ -22102,7 +22134,7 @@ var BaseLabels2 = /* @__PURE__ */ (() => {
 var Labels2 = class extends BaseLabels2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/languages.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/languages.mjs
 var BaseLanguages = /* @__PURE__ */ (() => {
   class BaseLanguages2 extends APIResource {
     /**
@@ -22131,7 +22163,7 @@ var BaseLanguages = /* @__PURE__ */ (() => {
 var Languages = class extends BaseLanguages {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/milestones.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/milestones.mjs
 var BaseMilestones = /* @__PURE__ */ (() => {
   class BaseMilestones2 extends APIResource {
     /**
@@ -22253,7 +22285,7 @@ var BaseMilestones = /* @__PURE__ */ (() => {
 var Milestones = class extends BaseMilestones {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/notifications.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/notifications.mjs
 var BaseNotifications2 = /* @__PURE__ */ (() => {
   class BaseNotifications3 extends APIResource {
     /**
@@ -22306,7 +22338,7 @@ var BaseNotifications2 = /* @__PURE__ */ (() => {
 var Notifications2 = class extends BaseNotifications2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/private-vulnerability-reporting.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/private-vulnerability-reporting.mjs
 var BasePrivateVulnerabilityReporting = /* @__PURE__ */ (() => {
   class BasePrivateVulnerabilityReporting2 extends APIResource {
     /**
@@ -22376,7 +22408,7 @@ var BasePrivateVulnerabilityReporting = /* @__PURE__ */ (() => {
 var PrivateVulnerabilityReporting = class extends BasePrivateVulnerabilityReporting {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/readme.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/readme.mjs
 var BaseReadme = /* @__PURE__ */ (() => {
   class BaseReadme2 extends APIResource {
     /**
@@ -22437,7 +22469,7 @@ var BaseReadme = /* @__PURE__ */ (() => {
 var Readme = class extends BaseReadme {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/rules.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/rules.mjs
 var BaseRules = /* @__PURE__ */ (() => {
   class BaseRules2 extends APIResource {
     /**
@@ -22466,7 +22498,7 @@ var BaseRules = /* @__PURE__ */ (() => {
 var Rules = class extends BaseRules {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/security-advisories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/security-advisories.mjs
 var BaseSecurityAdvisories = /* @__PURE__ */ (() => {
   class BaseSecurityAdvisories2 extends APIResource {
     /**
@@ -22679,7 +22711,7 @@ var BaseSecurityAdvisories = /* @__PURE__ */ (() => {
 var SecurityAdvisories = class extends BaseSecurityAdvisories {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/stats.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/stats.mjs
 var BaseStats = /* @__PURE__ */ (() => {
   class BaseStats2 extends APIResource {
     /**
@@ -22795,7 +22827,7 @@ var BaseStats = /* @__PURE__ */ (() => {
 var Stats = class extends BaseStats {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/subscription.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/subscription.mjs
 var BaseSubscription2 = /* @__PURE__ */ (() => {
   class BaseSubscription3 extends APIResource {
     /**
@@ -22864,7 +22896,7 @@ var BaseSubscription2 = /* @__PURE__ */ (() => {
 var Subscription2 = class extends BaseSubscription2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/tags.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/tags.mjs
 var BaseTags = /* @__PURE__ */ (() => {
   class BaseTags3 extends APIResource {
     /**
@@ -22895,7 +22927,7 @@ var BaseTags = /* @__PURE__ */ (() => {
 var Tags = class extends BaseTags {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/teams.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/teams.mjs
 var BaseTeams3 = /* @__PURE__ */ (() => {
   class BaseTeams5 extends APIResource {
     /**
@@ -22934,7 +22966,7 @@ var BaseTeams3 = /* @__PURE__ */ (() => {
 var Teams3 = class extends BaseTeams3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/topics.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/topics.mjs
 var BaseTopics = /* @__PURE__ */ (() => {
   class BaseTopics2 extends APIResource {
     /**
@@ -22975,7 +23007,7 @@ var BaseTopics = /* @__PURE__ */ (() => {
 var Topics = class extends BaseTopics {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/tory-invitations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/tory-invitations.mjs
 var BaseToryInvitations = /* @__PURE__ */ (() => {
   class BaseToryInvitations2 extends APIResource {
     /**
@@ -23034,7 +23066,7 @@ var BaseToryInvitations = /* @__PURE__ */ (() => {
 var ToryInvitations = class extends BaseToryInvitations {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/vulnerability-alerts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/vulnerability-alerts.mjs
 var BaseVulnerabilityAlerts = /* @__PURE__ */ (() => {
   class BaseVulnerabilityAlerts2 extends APIResource {
     /**
@@ -23110,7 +23142,7 @@ var BaseVulnerabilityAlerts = /* @__PURE__ */ (() => {
 var VulnerabilityAlerts = class extends BaseVulnerabilityAlerts {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/artifacts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/artifacts.mjs
 var BaseArtifacts = /* @__PURE__ */ (() => {
   class BaseArtifacts2 extends APIResource {
     /**
@@ -23206,7 +23238,7 @@ var BaseArtifacts = /* @__PURE__ */ (() => {
 var Artifacts = class extends BaseArtifacts {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/cache.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/cache.mjs
 var BaseCache2 = /* @__PURE__ */ (() => {
   class BaseCache3 extends APIResource {
     /**
@@ -23242,7 +23274,7 @@ var BaseCache2 = /* @__PURE__ */ (() => {
 var Cache2 = class extends BaseCache2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/caches.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/caches.mjs
 var BaseCaches = /* @__PURE__ */ (() => {
   class BaseCaches2 extends APIResource {
     /**
@@ -23320,7 +23352,7 @@ var BaseCaches = /* @__PURE__ */ (() => {
 var Caches = class extends BaseCaches {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/jobs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/jobs.mjs
 var BaseJobs = /* @__PURE__ */ (() => {
   class BaseJobs2 extends APIResource {
     /**
@@ -23397,7 +23429,7 @@ var BaseJobs = /* @__PURE__ */ (() => {
 var Jobs = class extends BaseJobs {
 };
 
-// node_modules/@stainless-api/github-internal/lib/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/lib/secrets.mjs
 var import_libsodium_wrappers = __toESM(require_libsodium_wrappers(), 1);
 async function encryptSecret(value, publicKey) {
   return import_libsodium_wrappers.default.ready.then(() => {
@@ -23409,7 +23441,7 @@ async function encryptSecret(value, publicKey) {
   });
 }
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/secrets.mjs
 var BaseSecrets4 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -23562,7 +23594,7 @@ var BaseSecrets4 = /* @__PURE__ */ (() => {
 var Secrets4 = class extends BaseSecrets4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/variables.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/variables.mjs
 var BaseVariables2 = /* @__PURE__ */ (() => {
   class BaseVariables4 extends APIResource {
     /**
@@ -23695,7 +23727,7 @@ var BaseVariables2 = /* @__PURE__ */ (() => {
 var Variables2 = class extends BaseVariables2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/workflows.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/workflows.mjs
 var BaseWorkflows = /* @__PURE__ */ (() => {
   class BaseWorkflows2 extends APIResource {
     /**
@@ -23900,7 +23932,7 @@ var BaseWorkflows = /* @__PURE__ */ (() => {
 var Workflows = class extends BaseWorkflows {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/oidc/customization/sub.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/oidc/customization/sub.mjs
 var BaseSub2 = /* @__PURE__ */ (() => {
   class BaseSub3 extends APIResource {
     /**
@@ -23954,7 +23986,7 @@ var BaseSub2 = /* @__PURE__ */ (() => {
 var Sub2 = class extends BaseSub2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/oidc/customization/customization.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/oidc/customization/customization.mjs
 var BaseCustomization2 = /* @__PURE__ */ (() => {
   class BaseCustomization3 extends APIResource {
   }
@@ -23978,7 +24010,7 @@ var Customization2 = /* @__PURE__ */ (() => {
   return Customization3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/oidc/oidc.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/oidc/oidc.mjs
 var BaseOidc2 = /* @__PURE__ */ (() => {
   class BaseOidc3 extends APIResource {
   }
@@ -24001,7 +24033,7 @@ var Oidc2 = /* @__PURE__ */ (() => {
   return Oidc3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/access.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/access.mjs
 var BaseAccess = /* @__PURE__ */ (() => {
   class BaseAccess2 extends APIResource {
     /**
@@ -24064,7 +24096,7 @@ var BaseAccess = /* @__PURE__ */ (() => {
 var Access = class extends BaseAccess {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/selected-actions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/selected-actions.mjs
 var BaseSelectedActions2 = /* @__PURE__ */ (() => {
   class BaseSelectedActions3 extends APIResource {
     /**
@@ -24122,7 +24154,7 @@ var BaseSelectedActions2 = /* @__PURE__ */ (() => {
 var SelectedActions2 = class extends BaseSelectedActions2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/workflow.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/workflow.mjs
 var BaseWorkflow2 = /* @__PURE__ */ (() => {
   class BaseWorkflow3 extends APIResource {
     /**
@@ -24186,7 +24218,7 @@ var BaseWorkflow2 = /* @__PURE__ */ (() => {
 var Workflow2 = class extends BaseWorkflow2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/permissions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/permissions/permissions.mjs
 var BasePermissions2 = /* @__PURE__ */ (() => {
   class BasePermissions3 extends APIResource {
     /**
@@ -24261,7 +24293,7 @@ var Permissions2 = /* @__PURE__ */ (() => {
   return Permissions3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/runners/labels.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/runners/labels.mjs
 var BaseLabels3 = /* @__PURE__ */ (() => {
   class BaseLabels5 extends APIResource {
     /**
@@ -24401,7 +24433,7 @@ var BaseLabels3 = /* @__PURE__ */ (() => {
 var Labels3 = class extends BaseLabels3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/runners/runners.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/runners/runners.mjs
 var BaseRunners3 = /* @__PURE__ */ (() => {
   class BaseRunners4 extends APIResource {
     /**
@@ -24604,7 +24636,7 @@ var Runners3 = /* @__PURE__ */ (() => {
   return Runners4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/runs/attempts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/runs/attempts.mjs
 var BaseAttempts = /* @__PURE__ */ (() => {
   class BaseAttempts2 extends APIResource {
     /**
@@ -24691,7 +24723,7 @@ var BaseAttempts = /* @__PURE__ */ (() => {
 var Attempts = class extends BaseAttempts {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/runs/logs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/runs/logs.mjs
 var BaseLogs = /* @__PURE__ */ (() => {
   class BaseLogs2 extends APIResource {
     /**
@@ -24752,7 +24784,7 @@ var BaseLogs = /* @__PURE__ */ (() => {
 var Logs = class extends BaseLogs {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/runs/pending-deployments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/runs/pending-deployments.mjs
 var BasePendingDeployments = /* @__PURE__ */ (() => {
   class BasePendingDeployments2 extends APIResource {
     /**
@@ -24821,7 +24853,7 @@ var BasePendingDeployments = /* @__PURE__ */ (() => {
 var PendingDeployments = class extends BasePendingDeployments {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/runs/runs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/runs/runs.mjs
 var BaseRuns = /* @__PURE__ */ (() => {
   class BaseRuns2 extends APIResource {
     /**
@@ -25151,7 +25183,7 @@ var Runs = /* @__PURE__ */ (() => {
   return Runs2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/actions/actions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/actions/actions.mjs
 var BaseActions2 = /* @__PURE__ */ (() => {
   class BaseActions3 extends APIResource {
     /**
@@ -25251,7 +25283,7 @@ var Actions2 = /* @__PURE__ */ (() => {
   return Actions3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/enforce-admins.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/enforce-admins.mjs
 var BaseEnforceAdmins = /* @__PURE__ */ (() => {
   class BaseEnforceAdmins2 extends APIResource {
     /**
@@ -25332,7 +25364,7 @@ var BaseEnforceAdmins = /* @__PURE__ */ (() => {
 var EnforceAdmins = class extends BaseEnforceAdmins {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-pull-request-reviews.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-pull-request-reviews.mjs
 var BaseRequiredPullRequestReviews = /* @__PURE__ */ (() => {
   class BaseRequiredPullRequestReviews2 extends APIResource {
     /**
@@ -25427,7 +25459,7 @@ var BaseRequiredPullRequestReviews = /* @__PURE__ */ (() => {
 var RequiredPullRequestReviews = class extends BaseRequiredPullRequestReviews {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-signatures.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-signatures.mjs
 var BaseRequiredSignatures = /* @__PURE__ */ (() => {
   class BaseRequiredSignatures2 extends APIResource {
     /**
@@ -25516,7 +25548,7 @@ var BaseRequiredSignatures = /* @__PURE__ */ (() => {
 var RequiredSignatures = class extends BaseRequiredSignatures {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-status-checks/contexts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-status-checks/contexts.mjs
 var BaseContexts = /* @__PURE__ */ (() => {
   class BaseContexts2 extends APIResource {
     /**
@@ -25625,7 +25657,7 @@ var BaseContexts = /* @__PURE__ */ (() => {
 var Contexts = class extends BaseContexts {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-status-checks/required-status-checks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/required-status-checks/required-status-checks.mjs
 var BaseRequiredStatusChecks = /* @__PURE__ */ (() => {
   class BaseRequiredStatusChecks2 extends APIResource {
     /**
@@ -25709,7 +25741,7 @@ var RequiredStatusChecks = /* @__PURE__ */ (() => {
   return RequiredStatusChecks2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/apps.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/apps.mjs
 var BaseApps2 = /* @__PURE__ */ (() => {
   class BaseApps3 extends APIResource {
     /**
@@ -25827,7 +25859,7 @@ var BaseApps2 = /* @__PURE__ */ (() => {
 var Apps2 = class extends BaseApps2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/teams.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/teams.mjs
 var BaseTeams4 = /* @__PURE__ */ (() => {
   class BaseTeams5 extends APIResource {
     /**
@@ -25948,7 +25980,7 @@ var BaseTeams4 = /* @__PURE__ */ (() => {
 var Teams4 = class extends BaseTeams4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/users.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/users.mjs
 var BaseUsers2 = /* @__PURE__ */ (() => {
   class BaseUsers4 extends APIResource {
     /**
@@ -26070,7 +26102,7 @@ var BaseUsers2 = /* @__PURE__ */ (() => {
 var Users2 = class extends BaseUsers2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/restrictions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/restrictions/restrictions.mjs
 var BaseRestrictions = /* @__PURE__ */ (() => {
   class BaseRestrictions2 extends APIResource {
     /**
@@ -26146,7 +26178,7 @@ var Restrictions = /* @__PURE__ */ (() => {
   return Restrictions2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/protection/protection.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/protection/protection.mjs
 var BaseProtection = /* @__PURE__ */ (() => {
   class BaseProtection2 extends APIResource {
     /**
@@ -26276,7 +26308,7 @@ var Protection = /* @__PURE__ */ (() => {
   return Protection2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/branches/branches.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/branches/branches.mjs
 var BaseBranches = /* @__PURE__ */ (() => {
   class BaseBranches2 extends APIResource {
     /**
@@ -26365,7 +26397,7 @@ var Branches = /* @__PURE__ */ (() => {
   return Branches3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/analyses.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/analyses.mjs
 var BaseAnalyses = /* @__PURE__ */ (() => {
   class BaseAnalyses2 extends APIResource {
     /**
@@ -26540,7 +26572,7 @@ var BaseAnalyses = /* @__PURE__ */ (() => {
 var Analyses = class extends BaseAnalyses {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/default-setup.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/default-setup.mjs
 var BaseDefaultSetup = /* @__PURE__ */ (() => {
   class BaseDefaultSetup2 extends APIResource {
     /**
@@ -26599,7 +26631,7 @@ var BaseDefaultSetup = /* @__PURE__ */ (() => {
 var DefaultSetup = class extends BaseDefaultSetup {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/sarifs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/sarifs.mjs
 var BaseSarifs = /* @__PURE__ */ (() => {
   class BaseSarifs2 extends APIResource {
     /**
@@ -26709,7 +26741,7 @@ var BaseSarifs = /* @__PURE__ */ (() => {
 var Sarifs = class extends BaseSarifs {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/alerts/autofix.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/alerts/autofix.mjs
 var BaseAutofix = /* @__PURE__ */ (() => {
   class BaseAutofix2 extends APIResource {
     /**
@@ -26795,7 +26827,7 @@ var BaseAutofix = /* @__PURE__ */ (() => {
 var Autofix = class extends BaseAutofix {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/alerts/instances.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/alerts/instances.mjs
 var BaseInstances = /* @__PURE__ */ (() => {
   class BaseInstances2 extends APIResource {
     /**
@@ -26832,7 +26864,7 @@ var BaseInstances = /* @__PURE__ */ (() => {
 var Instances = class extends BaseInstances {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/alerts/alerts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/alerts/alerts.mjs
 var BaseAlerts = /* @__PURE__ */ (() => {
   class BaseAlerts4 extends APIResource {
     /**
@@ -26932,7 +26964,7 @@ var Alerts = /* @__PURE__ */ (() => {
   return Alerts4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/codeql/databases.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/codeql/databases.mjs
 var BaseDatabases = /* @__PURE__ */ (() => {
   class BaseDatabases2 extends APIResource {
     /**
@@ -27016,7 +27048,7 @@ var BaseDatabases = /* @__PURE__ */ (() => {
 var Databases = class extends BaseDatabases {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/codeql/variant-analyses.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/codeql/variant-analyses.mjs
 var BaseVariantAnalyses = /* @__PURE__ */ (() => {
   class BaseVariantAnalyses2 extends APIResource {
     /**
@@ -27109,7 +27141,7 @@ var BaseVariantAnalyses = /* @__PURE__ */ (() => {
 var VariantAnalyses = class extends BaseVariantAnalyses {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/codeql/codeql.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/codeql/codeql.mjs
 var BaseCodeql = /* @__PURE__ */ (() => {
   class BaseCodeql2 extends APIResource {
   }
@@ -27135,7 +27167,7 @@ var Codeql = /* @__PURE__ */ (() => {
   return Codeql2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/code-scanning/code-scanning.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/code-scanning/code-scanning.mjs
 var BaseCodeScanning2 = /* @__PURE__ */ (() => {
   class BaseCodeScanning3 extends APIResource {
   }
@@ -27169,7 +27201,7 @@ var CodeScanning2 = /* @__PURE__ */ (() => {
   return CodeScanning3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/codespaces/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/codespaces/secrets.mjs
 var BaseSecrets5 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -27294,7 +27326,7 @@ var BaseSecrets5 = /* @__PURE__ */ (() => {
 var Secrets5 = class extends BaseSecrets5 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/codespaces/codespaces.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/codespaces/codespaces.mjs
 var BaseCodespaces3 = /* @__PURE__ */ (() => {
   class BaseCodespaces5 extends APIResource {
     /**
@@ -27440,7 +27472,7 @@ var Codespaces3 = /* @__PURE__ */ (() => {
   return Codespaces5;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/comments/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/comments/reactions.mjs
 var BaseReactions4 = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -27519,7 +27551,7 @@ var BaseReactions4 = /* @__PURE__ */ (() => {
 var Reactions4 = class extends BaseReactions4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/comments/comments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/comments/comments.mjs
 var BaseComments4 = /* @__PURE__ */ (() => {
   class BaseComments7 extends APIResource {
     /**
@@ -27653,7 +27685,7 @@ var Comments4 = /* @__PURE__ */ (() => {
   return Comments7;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/commits/comments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/commits/comments.mjs
 var BaseComments5 = /* @__PURE__ */ (() => {
   class BaseComments7 extends APIResource {
     /**
@@ -27748,7 +27780,7 @@ var BaseComments5 = /* @__PURE__ */ (() => {
 var Comments5 = class extends BaseComments5 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/commits/commits.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/commits/commits.mjs
 var BaseCommits = /* @__PURE__ */ (() => {
   class BaseCommits3 extends APIResource {
     /**
@@ -28035,7 +28067,7 @@ var Commits = /* @__PURE__ */ (() => {
   return Commits3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/dependabot/alerts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/dependabot/alerts.mjs
 var BaseAlerts2 = /* @__PURE__ */ (() => {
   class BaseAlerts4 extends APIResource {
     /**
@@ -28114,7 +28146,7 @@ var BaseAlerts2 = /* @__PURE__ */ (() => {
 var Alerts2 = class extends BaseAlerts2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/dependabot/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/dependabot/secrets.mjs
 var BaseSecrets6 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -28239,7 +28271,7 @@ var BaseSecrets6 = /* @__PURE__ */ (() => {
 var Secrets6 = class extends BaseSecrets6 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/dependabot/dependabot.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/dependabot/dependabot.mjs
 var BaseDependabot3 = /* @__PURE__ */ (() => {
   class BaseDependabot4 extends APIResource {
   }
@@ -28264,7 +28296,7 @@ var Dependabot3 = /* @__PURE__ */ (() => {
   return Dependabot4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/deployments/statuses.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/deployments/statuses.mjs
 var BaseStatuses = /* @__PURE__ */ (() => {
   class BaseStatuses2 extends APIResource {
     /**
@@ -28339,7 +28371,7 @@ var BaseStatuses = /* @__PURE__ */ (() => {
 var Statuses = class extends BaseStatuses {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/deployments/deployments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/deployments/deployments.mjs
 var BaseDeployments = /* @__PURE__ */ (() => {
   class BaseDeployments3 extends APIResource {
     /**
@@ -28506,7 +28538,7 @@ var Deployments = /* @__PURE__ */ (() => {
   return Deployments3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/environments/deployment-branch-policies.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/environments/deployment-branch-policies.mjs
 var BaseDeploymentBranchPolicies = /* @__PURE__ */ (() => {
   class BaseDeploymentBranchPolicies2 extends APIResource {
     /**
@@ -28627,7 +28659,7 @@ var BaseDeploymentBranchPolicies = /* @__PURE__ */ (() => {
 var DeploymentBranchPolicies = class extends BaseDeploymentBranchPolicies {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/environments/deployment-protection-rules.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/environments/deployment-protection-rules.mjs
 var BaseDeploymentProtectionRules = /* @__PURE__ */ (() => {
   class BaseDeploymentProtectionRules2 extends APIResource {
     /**
@@ -28775,7 +28807,7 @@ var BaseDeploymentProtectionRules = /* @__PURE__ */ (() => {
 var DeploymentProtectionRules = class extends BaseDeploymentProtectionRules {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/environments/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/environments/secrets.mjs
 var BaseSecrets7 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -28920,7 +28952,7 @@ var BaseSecrets7 = /* @__PURE__ */ (() => {
 var Secrets7 = class extends BaseSecrets7 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/environments/variables.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/environments/variables.mjs
 var BaseVariables3 = /* @__PURE__ */ (() => {
   class BaseVariables4 extends APIResource {
     /**
@@ -29063,7 +29095,7 @@ var BaseVariables3 = /* @__PURE__ */ (() => {
 var Variables3 = class extends BaseVariables3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/environments/environments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/environments/environments.mjs
 var BaseEnvironments = /* @__PURE__ */ (() => {
   class BaseEnvironments2 extends APIResource {
     /**
@@ -29199,7 +29231,7 @@ var Environments = /* @__PURE__ */ (() => {
   return Environments2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/git-refs/blobs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/git-refs/blobs.mjs
 var BaseBlobs = /* @__PURE__ */ (() => {
   class BaseBlobs2 extends APIResource {
     /**
@@ -29256,7 +29288,7 @@ var BaseBlobs = /* @__PURE__ */ (() => {
 var Blobs = class extends BaseBlobs {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/git-refs/commits.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/git-refs/commits.mjs
 var BaseCommits2 = /* @__PURE__ */ (() => {
   class BaseCommits3 extends APIResource {
     /**
@@ -29379,7 +29411,7 @@ var BaseCommits2 = /* @__PURE__ */ (() => {
 var Commits2 = class extends BaseCommits2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/git-refs/tags.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/git-refs/tags.mjs
 var BaseTags2 = /* @__PURE__ */ (() => {
   class BaseTags3 extends APIResource {
     /**
@@ -29500,7 +29532,7 @@ var BaseTags2 = /* @__PURE__ */ (() => {
 var Tags2 = class extends BaseTags2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/git-refs/trees.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/git-refs/trees.mjs
 var BaseTrees = /* @__PURE__ */ (() => {
   class BaseTrees2 extends APIResource {
     /**
@@ -29571,7 +29603,7 @@ var BaseTrees = /* @__PURE__ */ (() => {
 var Trees = class extends BaseTrees {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/git-refs/git-refs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/git-refs/git-refs.mjs
 var BaseGitRefs = /* @__PURE__ */ (() => {
   class BaseGitRefs2 extends APIResource {
     /**
@@ -29715,7 +29747,7 @@ var GitRefs = /* @__PURE__ */ (() => {
   return GitRefs2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/hooks/config.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/hooks/config.mjs
 var BaseConfig3 = /* @__PURE__ */ (() => {
   class BaseConfig4 extends APIResource {
     /**
@@ -29773,7 +29805,7 @@ var BaseConfig3 = /* @__PURE__ */ (() => {
 var Config3 = class extends BaseConfig3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/hooks/deliveries.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/hooks/deliveries.mjs
 var BaseDeliveries3 = /* @__PURE__ */ (() => {
   class BaseDeliveries4 extends APIResource {
     /**
@@ -29839,7 +29871,7 @@ var BaseDeliveries3 = /* @__PURE__ */ (() => {
 var Deliveries3 = class extends BaseDeliveries3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/hooks/hooks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/hooks/hooks.mjs
 var BaseHooks2 = /* @__PURE__ */ (() => {
   class BaseHooks3 extends APIResource {
     /**
@@ -30006,7 +30038,7 @@ var Hooks2 = /* @__PURE__ */ (() => {
   return Hooks3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/assignees.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/assignees.mjs
 var BaseAssignees2 = /* @__PURE__ */ (() => {
   class BaseAssignees3 extends APIResource {
     /**
@@ -30086,7 +30118,7 @@ var BaseAssignees2 = /* @__PURE__ */ (() => {
 var Assignees2 = class extends BaseAssignees2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/events.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/events.mjs
 var BaseEvents2 = /* @__PURE__ */ (() => {
   class BaseEvents4 extends APIResource {
     /**
@@ -30133,7 +30165,7 @@ var BaseEvents2 = /* @__PURE__ */ (() => {
 var Events2 = class extends BaseEvents2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/labels.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/labels.mjs
 var BaseLabels4 = /* @__PURE__ */ (() => {
   class BaseLabels5 extends APIResource {
     /**
@@ -30236,7 +30268,7 @@ var BaseLabels4 = /* @__PURE__ */ (() => {
 var Labels4 = class extends BaseLabels4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/lock.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/lock.mjs
 var BaseLock = /* @__PURE__ */ (() => {
   class BaseLock2 extends APIResource {
     /**
@@ -30293,7 +30325,7 @@ var BaseLock = /* @__PURE__ */ (() => {
 var Lock = class extends BaseLock {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/reactions.mjs
 var BaseReactions5 = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -30370,7 +30402,7 @@ var BaseReactions5 = /* @__PURE__ */ (() => {
 var Reactions5 = class extends BaseReactions5 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/sub-issues.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/sub-issues.mjs
 var BaseSubIssues = /* @__PURE__ */ (() => {
   class BaseSubIssues2 extends APIResource {
     /**
@@ -30477,7 +30509,7 @@ var BaseSubIssues = /* @__PURE__ */ (() => {
 var SubIssues = class extends BaseSubIssues {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/timeline.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/timeline.mjs
 var BaseTimeline = /* @__PURE__ */ (() => {
   class BaseTimeline2 extends APIResource {
     /**
@@ -30509,7 +30541,7 @@ var BaseTimeline = /* @__PURE__ */ (() => {
 var Timeline = class extends BaseTimeline {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/issues/issues.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/issues/issues.mjs
 var BaseIssues2 = /* @__PURE__ */ (() => {
   class BaseIssues3 extends APIResource {
     /**
@@ -30808,7 +30840,7 @@ var Issues2 = /* @__PURE__ */ (() => {
   return Issues3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/pages/builds.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pages/builds.mjs
 var BaseBuilds = /* @__PURE__ */ (() => {
   class BaseBuilds2 extends APIResource {
     /**
@@ -30900,7 +30932,7 @@ var BaseBuilds = /* @__PURE__ */ (() => {
 var Builds = class extends BaseBuilds {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/pages/deployments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pages/deployments.mjs
 var BaseDeployments2 = /* @__PURE__ */ (() => {
   class BaseDeployments3 extends APIResource {
     /**
@@ -30976,7 +31008,7 @@ var BaseDeployments2 = /* @__PURE__ */ (() => {
 var Deployments2 = class extends BaseDeployments2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/pages/pages.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pages/pages.mjs
 var BasePages = /* @__PURE__ */ (() => {
   class BasePages2 extends APIResource {
     /**
@@ -31119,7 +31151,7 @@ var Pages = /* @__PURE__ */ (() => {
   return Pages2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/properties/values.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/properties/values.mjs
 var BaseValues2 = /* @__PURE__ */ (() => {
   class BaseValues3 extends APIResource {
     /**
@@ -31179,7 +31211,7 @@ var BaseValues2 = /* @__PURE__ */ (() => {
 var Values2 = class extends BaseValues2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/properties/properties.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/properties/properties.mjs
 var BaseProperties2 = /* @__PURE__ */ (() => {
   class BaseProperties3 extends APIResource {
   }
@@ -31201,7 +31233,7 @@ var Properties2 = /* @__PURE__ */ (() => {
   return Properties3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/pulls/merge.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pulls/merge.mjs
 var BaseMerge = /* @__PURE__ */ (() => {
   class BaseMerge2 extends APIResource {
     /**
@@ -31259,7 +31291,7 @@ var BaseMerge = /* @__PURE__ */ (() => {
 var Merge = class extends BaseMerge {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/pulls/requested-reviewers.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pulls/requested-reviewers.mjs
 var BaseRequestedReviewers = /* @__PURE__ */ (() => {
   class BaseRequestedReviewers2 extends APIResource {
     /**
@@ -31343,7 +31375,7 @@ var BaseRequestedReviewers = /* @__PURE__ */ (() => {
 var RequestedReviewers = class extends BaseRequestedReviewers {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/pulls/reviews.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pulls/reviews.mjs
 var BaseReviews = /* @__PURE__ */ (() => {
   class BaseReviews2 extends APIResource {
     /**
@@ -31670,7 +31702,7 @@ var BaseReviews = /* @__PURE__ */ (() => {
 var Reviews = class extends BaseReviews {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/pulls/comments/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pulls/comments/reactions.mjs
 var BaseReactions6 = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -31747,7 +31779,7 @@ var BaseReactions6 = /* @__PURE__ */ (() => {
 var Reactions6 = class extends BaseReactions6 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/pulls/comments/comments.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pulls/comments/comments.mjs
 var BaseComments6 = /* @__PURE__ */ (() => {
   class BaseComments7 extends APIResource {
     /**
@@ -31934,7 +31966,7 @@ var Comments6 = /* @__PURE__ */ (() => {
   return Comments7;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/pulls/pulls.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/pulls/pulls.mjs
 var BasePulls = /* @__PURE__ */ (() => {
   class BasePulls2 extends APIResource {
     /**
@@ -32381,7 +32413,7 @@ var Pulls = /* @__PURE__ */ (() => {
   return Pulls2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/releases/assets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/releases/assets.mjs
 var BaseAssets = /* @__PURE__ */ (() => {
   class BaseAssets2 extends APIResource {
     /**
@@ -32472,7 +32504,7 @@ var BaseAssets = /* @__PURE__ */ (() => {
 var Assets = class extends BaseAssets {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/releases/reactions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/releases/reactions.mjs
 var BaseReactions7 = /* @__PURE__ */ (() => {
   class BaseReactions8 extends APIResource {
     /**
@@ -32551,7 +32583,7 @@ var BaseReactions7 = /* @__PURE__ */ (() => {
 var Reactions7 = class extends BaseReactions7 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/releases/releases.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/releases/releases.mjs
 var BaseReleases = /* @__PURE__ */ (() => {
   class BaseReleases2 extends APIResource {
     /**
@@ -32741,7 +32773,7 @@ var Releases = /* @__PURE__ */ (() => {
   return Releases2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/rulesets/history.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/rulesets/history.mjs
 var BaseHistory2 = /* @__PURE__ */ (() => {
   class BaseHistory3 extends APIResource {
     /**
@@ -32791,7 +32823,7 @@ var BaseHistory2 = /* @__PURE__ */ (() => {
 var History2 = class extends BaseHistory2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/rulesets/rule-suites.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/rulesets/rule-suites.mjs
 var BaseRuleSuites2 = /* @__PURE__ */ (() => {
   class BaseRuleSuites3 extends APIResource {
     /**
@@ -32842,7 +32874,7 @@ var BaseRuleSuites2 = /* @__PURE__ */ (() => {
 var RuleSuites2 = class extends BaseRuleSuites2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/rulesets/rulesets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/rulesets/rulesets.mjs
 var BaseRulesets2 = /* @__PURE__ */ (() => {
   class BaseRulesets3 extends APIResource {
     /**
@@ -33001,7 +33033,7 @@ var Rulesets2 = /* @__PURE__ */ (() => {
   return Rulesets3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/secret-scanning/alerts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/secret-scanning/alerts.mjs
 var BaseAlerts3 = /* @__PURE__ */ (() => {
   class BaseAlerts4 extends APIResource {
     /**
@@ -33119,7 +33151,7 @@ var BaseAlerts3 = /* @__PURE__ */ (() => {
 var Alerts3 = class extends BaseAlerts3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/secret-scanning/secret-scanning.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/secret-scanning/secret-scanning.mjs
 var BaseSecretScanning3 = /* @__PURE__ */ (() => {
   class BaseSecretScanning4 extends APIResource {
     /**
@@ -33190,7 +33222,7 @@ var SecretScanning3 = /* @__PURE__ */ (() => {
   return SecretScanning4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/traffic/popular.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/traffic/popular.mjs
 var BasePopular = /* @__PURE__ */ (() => {
   class BasePopular2 extends APIResource {
     /**
@@ -33236,7 +33268,7 @@ var BasePopular = /* @__PURE__ */ (() => {
 var Popular = class extends BasePopular {
 };
 
-// node_modules/@stainless-api/github-internal/resources/repos/traffic/traffic.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/traffic/traffic.mjs
 var BaseTraffic = /* @__PURE__ */ (() => {
   class BaseTraffic2 extends APIResource {
     /**
@@ -33289,7 +33321,7 @@ var Traffic = /* @__PURE__ */ (() => {
   return Traffic2;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/repos/repos.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/repos/repos.mjs
 var BaseRepos3 = /* @__PURE__ */ (() => {
   class BaseRepos6 extends APIResource {
     constructor() {
@@ -34186,7 +34218,7 @@ var Repos3 = /* @__PURE__ */ (() => {
   return Repos6;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/blocks.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/blocks.mjs
 var BaseBlocks2 = /* @__PURE__ */ (() => {
   class BaseBlocks3 extends APIResource {
     /**
@@ -34255,7 +34287,7 @@ var BaseBlocks2 = /* @__PURE__ */ (() => {
 var Blocks2 = class extends BaseBlocks2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/docker.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/docker.mjs
 var BaseDocker2 = /* @__PURE__ */ (() => {
   class BaseDocker3 extends APIResource {
     /**
@@ -34298,7 +34330,7 @@ var BaseDocker2 = /* @__PURE__ */ (() => {
 var Docker2 = class extends BaseDocker2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/emails.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/emails.mjs
 var BaseEmails = /* @__PURE__ */ (() => {
   class BaseEmails2 extends APIResource {
     /**
@@ -34375,7 +34407,7 @@ var BaseEmails = /* @__PURE__ */ (() => {
 var Emails = class extends BaseEmails {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/events.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/events.mjs
 var BaseEvents3 = /* @__PURE__ */ (() => {
   class BaseEvents4 extends APIResource {
     /**
@@ -34449,7 +34481,7 @@ var BaseEvents3 = /* @__PURE__ */ (() => {
 var Events3 = class extends BaseEvents3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/following.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/following.mjs
 var BaseFollowing = /* @__PURE__ */ (() => {
   class BaseFollowing2 extends APIResource {
     /**
@@ -34498,7 +34530,7 @@ var BaseFollowing = /* @__PURE__ */ (() => {
 var Following = class extends BaseFollowing {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/gpg-keys.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/gpg-keys.mjs
 var BaseGpgKeys = /* @__PURE__ */ (() => {
   class BaseGpgKeys2 extends APIResource {
     /**
@@ -34574,7 +34606,7 @@ var BaseGpgKeys = /* @__PURE__ */ (() => {
 var GpgKeys = class extends BaseGpgKeys {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/interaction-limits.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/interaction-limits.mjs
 var BaseInteractionLimits3 = /* @__PURE__ */ (() => {
   class BaseInteractionLimits4 extends APIResource {
     /**
@@ -34630,7 +34662,7 @@ var BaseInteractionLimits3 = /* @__PURE__ */ (() => {
 var InteractionLimits3 = class extends BaseInteractionLimits3 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/keys.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/keys.mjs
 var BaseKeys2 = /* @__PURE__ */ (() => {
   class BaseKeys3 extends APIResource {
     /**
@@ -34705,7 +34737,7 @@ var BaseKeys2 = /* @__PURE__ */ (() => {
 var Keys2 = class extends BaseKeys2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/marketplace-purchases.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/marketplace-purchases.mjs
 var BaseMarketplacePurchases = /* @__PURE__ */ (() => {
   class BaseMarketplacePurchases2 extends APIResource {
     /**
@@ -34746,7 +34778,7 @@ var BaseMarketplacePurchases = /* @__PURE__ */ (() => {
 var MarketplacePurchases = class extends BaseMarketplacePurchases {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/received-events.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/received-events.mjs
 var BaseReceivedEvents = /* @__PURE__ */ (() => {
   class BaseReceivedEvents2 extends APIResource {
     /**
@@ -34797,7 +34829,7 @@ var BaseReceivedEvents = /* @__PURE__ */ (() => {
 var ReceivedEvents = class extends BaseReceivedEvents {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/repos.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/repos.mjs
 var BaseRepos4 = /* @__PURE__ */ (() => {
   class BaseRepos6 extends APIResource {
     /**
@@ -35097,7 +35129,7 @@ var BaseRepos4 = /* @__PURE__ */ (() => {
 var Repos4 = class extends BaseRepos4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/social-accounts.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/social-accounts.mjs
 var BaseSocialAccounts = /* @__PURE__ */ (() => {
   class BaseSocialAccounts2 extends APIResource {
     /**
@@ -35169,7 +35201,7 @@ var BaseSocialAccounts = /* @__PURE__ */ (() => {
 var SocialAccounts = class extends BaseSocialAccounts {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/ssh-signing-keys.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/ssh-signing-keys.mjs
 var BaseSSHSigningKeys = /* @__PURE__ */ (() => {
   class BaseSSHSigningKeys2 extends APIResource {
     /**
@@ -35253,7 +35285,7 @@ var BaseSSHSigningKeys = /* @__PURE__ */ (() => {
 var SSHSigningKeys = class extends BaseSSHSigningKeys {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/codespaces/exports.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/codespaces/exports.mjs
 var BaseExports = /* @__PURE__ */ (() => {
   class BaseExports2 extends APIResource {
     /**
@@ -35306,7 +35338,7 @@ var BaseExports = /* @__PURE__ */ (() => {
 var Exports = class extends BaseExports {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/codespaces/secrets/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/codespaces/secrets/repositories.mjs
 var BaseRepositories8 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -35411,7 +35443,7 @@ var BaseRepositories8 = /* @__PURE__ */ (() => {
 var Repositories8 = class extends BaseRepositories8 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/codespaces/secrets/secrets.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/codespaces/secrets/secrets.mjs
 var BaseSecrets8 = /* @__PURE__ */ (() => {
   class BaseSecrets9 extends APIResource {
     /**
@@ -35538,7 +35570,7 @@ var Secrets8 = /* @__PURE__ */ (() => {
   return Secrets9;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/codespaces/codespaces.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/codespaces/codespaces.mjs
 var BaseCodespaces4 = /* @__PURE__ */ (() => {
   class BaseCodespaces5 extends APIResource {
     /**
@@ -35722,7 +35754,7 @@ var Codespaces4 = /* @__PURE__ */ (() => {
   return Codespaces5;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/installations/repositories.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/installations/repositories.mjs
 var BaseRepositories9 = /* @__PURE__ */ (() => {
   class BaseRepositories10 extends APIResource {
     /**
@@ -35797,7 +35829,7 @@ var BaseRepositories9 = /* @__PURE__ */ (() => {
 var Repositories9 = class extends BaseRepositories9 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/installations/installations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/installations/installations.mjs
 var BaseInstallations2 = /* @__PURE__ */ (() => {
   class BaseInstallations3 extends APIResource {
     /**
@@ -35838,7 +35870,7 @@ var Installations2 = /* @__PURE__ */ (() => {
   return Installations3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/memberships/orgs.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/memberships/orgs.mjs
 var BaseOrgs2 = /* @__PURE__ */ (() => {
   class BaseOrgs3 extends APIResource {
     /**
@@ -35899,7 +35931,7 @@ var BaseOrgs2 = /* @__PURE__ */ (() => {
 var Orgs2 = class extends BaseOrgs2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/memberships/memberships.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/memberships/memberships.mjs
 var BaseMemberships3 = /* @__PURE__ */ (() => {
   class BaseMemberships4 extends APIResource {
   }
@@ -35921,7 +35953,7 @@ var Memberships3 = /* @__PURE__ */ (() => {
   return Memberships4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/migrations/archive.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/migrations/archive.mjs
 var BaseArchive2 = /* @__PURE__ */ (() => {
   class BaseArchive3 extends APIResource {
     /**
@@ -35993,7 +36025,7 @@ var BaseArchive2 = /* @__PURE__ */ (() => {
 var Archive2 = class extends BaseArchive2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/migrations/repos.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/migrations/repos.mjs
 var BaseRepos5 = /* @__PURE__ */ (() => {
   class BaseRepos6 extends APIResource {
     /**
@@ -36030,7 +36062,7 @@ var BaseRepos5 = /* @__PURE__ */ (() => {
 var Repos5 = class extends BaseRepos5 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/migrations/migrations.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/migrations/migrations.mjs
 var BaseMigrations2 = /* @__PURE__ */ (() => {
   class BaseMigrations3 extends APIResource {
     /**
@@ -36122,7 +36154,7 @@ var Migrations2 = /* @__PURE__ */ (() => {
   return Migrations3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/packages/versions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/packages/versions.mjs
 var BaseVersions2 = /* @__PURE__ */ (() => {
   class BaseVersions4 extends APIResource {
     /**
@@ -36237,7 +36269,7 @@ var BaseVersions2 = /* @__PURE__ */ (() => {
 var Versions2 = class extends BaseVersions2 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/packages/packages.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/packages/packages.mjs
 var BasePackages2 = /* @__PURE__ */ (() => {
   class BasePackages3 extends APIResource {
     /**
@@ -36369,7 +36401,7 @@ var Packages2 = /* @__PURE__ */ (() => {
   return Packages3;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/settings/billing.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/settings/billing.mjs
 var BaseBilling4 = /* @__PURE__ */ (() => {
   class BaseBilling5 extends APIResource {
     /**
@@ -36450,7 +36482,7 @@ var BaseBilling4 = /* @__PURE__ */ (() => {
 var Billing4 = class extends BaseBilling4 {
 };
 
-// node_modules/@stainless-api/github-internal/resources/users/settings/settings.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/settings/settings.mjs
 var BaseSettings3 = /* @__PURE__ */ (() => {
   class BaseSettings4 extends APIResource {
   }
@@ -36472,7 +36504,7 @@ var Settings3 = /* @__PURE__ */ (() => {
   return Settings4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/users/users.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/users/users.mjs
 var BaseUsers3 = /* @__PURE__ */ (() => {
   class BaseUsers4 extends APIResource {
     /**
@@ -36820,7 +36852,7 @@ var Users3 = /* @__PURE__ */ (() => {
   return Users4;
 })();
 
-// node_modules/@stainless-api/github-internal/resources/versions.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/resources/versions.mjs
 var BaseVersions3 = /* @__PURE__ */ (() => {
   class BaseVersions4 extends APIResource {
     /**
@@ -36836,7 +36868,7 @@ var BaseVersions3 = /* @__PURE__ */ (() => {
 var Versions3 = class extends BaseVersions3 {
 };
 
-// node_modules/@stainless-api/github-internal/internal/utils/env.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/internal/utils/env.mjs
 var readEnv = (env) => {
   if (typeof globalThis.process !== "undefined") {
     return globalThis.process.env?.[env]?.trim() ?? void 0;
@@ -36847,7 +36879,7 @@ var readEnv = (env) => {
   return void 0;
 };
 
-// node_modules/@stainless-api/github-internal/lib/auth.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/lib/auth.mjs
 var import_jsonwebtoken = __toESM(require_jsonwebtoken(), 1);
 async function getAuthToken({ authMethods, owner, repo, logger: logger2 }) {
   const method = authMethods.find((method2) => method2.owner === owner) ?? authMethods.at(-1);
@@ -36894,7 +36926,7 @@ async function getAppToken(method) {
   return { authToken: appToken, expires: appTokenExpires };
 }
 
-// node_modules/@stainless-api/github-internal/client.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/client.mjs
 var _BaseGitHub_instances;
 var _BaseGitHub_encoder;
 var _BaseGitHub_baseURLOverridden;
@@ -37399,7 +37431,7 @@ var GitHub = /* @__PURE__ */ (() => {
   return GitHub2;
 })();
 
-// node_modules/@stainless-api/github-internal/tree-shakable.mjs
+// node_modules/.pnpm/@stainless-api+github-internal@0.15.0/node_modules/@stainless-api/github-internal/tree-shakable.mjs
 function createClient(options) {
   const client = new BaseGitHub(options);
   for (const ResourceClass of options.resources) {
@@ -38559,7 +38591,7 @@ async function generateAICommitMessage(stainless, params) {
   return result.ai_commit_message;
 }
 
-// node_modules/nano-spawn/source/context.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/context.js
 var import_node_process = __toESM(require("node:process"), 1);
 var import_node_util = require("node:util");
 var getContext = (raw) => ({
@@ -38569,7 +38601,7 @@ var getContext = (raw) => ({
 });
 var getCommandPart = (part) => /[^\w./-]/.test(part) ? `'${part.replaceAll("'", "'\\''")}'` : part;
 
-// node_modules/nano-spawn/source/options.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/options.js
 var import_node_path = __toESM(require("node:path"), 1);
 var import_node_url = require("node:url");
 var import_node_process2 = __toESM(require("node:process"), 1);
@@ -38601,12 +38633,12 @@ var addLocalPath = ({ Path = "", PATH = Path, ...env }, cwd) => {
 };
 var getLocalPaths = (localPaths, localPath) => localPaths.at(-1) === localPath ? localPaths : getLocalPaths([...localPaths, localPath], import_node_path.default.resolve(localPath, ".."));
 
-// node_modules/nano-spawn/source/spawn.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/spawn.js
 var import_node_child_process = require("node:child_process");
 var import_node_events2 = require("node:events");
 var import_node_process5 = __toESM(require("node:process"), 1);
 
-// node_modules/nano-spawn/source/windows.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/windows.js
 var import_promises = __toESM(require("node:fs/promises"), 1);
 var import_node_path2 = __toESM(require("node:path"), 1);
 var import_node_process3 = __toESM(require("node:process"), 1);
@@ -38640,7 +38672,7 @@ var exeExtensions = [".exe", ".com"];
 var escapeArgument = (argument) => escapeFile(escapeFile(`"${argument.replaceAll(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1")}"`));
 var escapeFile = (file) => file.replaceAll(/([()\][%!^"`<>&|;, *?])/g, "^$1");
 
-// node_modules/nano-spawn/source/result.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/result.js
 var import_node_events = require("node:events");
 var import_node_process4 = __toESM(require("node:process"), 1);
 var getResult = async (nodeChildProcess, { input }, context) => {
@@ -38699,7 +38731,7 @@ var getOutputs = ({ state: { stdout, stderr, output }, command, start }) => ({
 });
 var getOutput = (output) => output.at(-1) === "\n" ? output.slice(0, output.at(-2) === "\r" ? -2 : -1) : output;
 
-// node_modules/nano-spawn/source/spawn.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/spawn.js
 var spawnSubprocess = async (file, commandArguments, options, context) => {
   try {
     if (["node", "node.exe"].includes(file.toLowerCase())) {
@@ -38733,7 +38765,7 @@ var bufferOutput = (stream, { state }, streamName) => {
   }
 };
 
-// node_modules/nano-spawn/source/pipe.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/pipe.js
 var import_promises2 = require("node:stream/promises");
 var handlePipe = async (subprocesses) => {
   const [[from, to]] = await Promise.all([Promise.allSettled(subprocesses), pipeStreams(subprocesses)]);
@@ -38767,7 +38799,7 @@ var closeStdin = async (nodeChildProcess) => {
   stdin.end();
 };
 
-// node_modules/nano-spawn/source/iterable.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/iterable.js
 var readline = __toESM(require("node:readline/promises"), 1);
 var lineIterator = async function* (subprocess, { state }, streamName) {
   if (state.isIterating === false) {
@@ -38817,7 +38849,7 @@ var getNext = async (iterator) => {
   }
 };
 
-// node_modules/nano-spawn/source/index.js
+// node_modules/.pnpm/nano-spawn@1.0.3/node_modules/nano-spawn/source/index.js
 function spawn2(file, second, third, previous) {
   const [commandArguments = [], options = {}] = Array.isArray(second) ? [second, third] : [[], second];
   const context = getContext([file, ...commandArguments]);
@@ -39027,7 +39059,39 @@ async function isConfigChanged({
   return changed;
 }
 
-// node_modules/diff/libesm/diff/base.js
+// src/resolve.ts
+async function resolveProject(client, projectInput) {
+  if (projectInput) {
+    return { projectName: projectInput, orgName: void 0 };
+  }
+  const page = await client.projects.list({ limit: 6 });
+  const projects = page.data;
+  if (projects.length === 0) {
+    throw new Error(
+      "No projects found for the given API key. Please specify the `project` input explicitly."
+    );
+  }
+  if (projects.length === 1) {
+    const project = projects[0];
+    logger.info(`Auto-detected project: ${project.slug}`);
+    return { projectName: project.slug, orgName: project.org };
+  }
+  const slugs = projects.slice(0, 5).map((p) => p.slug).join(", ");
+  const suffix = projects.length > 5 ? ", ..." : "";
+  throw new Error(
+    `Multiple projects found: ${slugs}${suffix}. Please specify the \`project\` input explicitly.`
+  );
+}
+async function resolveOrg(client, orgName) {
+  if (orgName) {
+    return orgName;
+  }
+  const project = await client.projects.retrieve();
+  logger.info(`Auto-detected org: ${project.org}`);
+  return project.org;
+}
+
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/diff/base.js
 var Diff = class {
   diff(oldStr, newStr, options = {}) {
     let callback;
@@ -39229,7 +39293,7 @@ var Diff = class {
   }
 };
 
-// node_modules/diff/libesm/util/string.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/util/string.js
 function hasOnlyWinLineEndings(string) {
   return string.includes("\r\n") && !string.startsWith("\n") && !string.match(/[^\r]\n/);
 }
@@ -39237,7 +39301,7 @@ function hasOnlyUnixLineEndings(string) {
   return !string.includes("\r\n") && string.includes("\n");
 }
 
-// node_modules/diff/libesm/diff/line.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/diff/line.js
 var LineDiff = class extends Diff {
   constructor() {
     super(...arguments);
@@ -39285,7 +39349,7 @@ function tokenize(value, options) {
   return retLines;
 }
 
-// node_modules/diff/libesm/patch/line-endings.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/patch/line-endings.js
 function unixToWin(patch) {
   if (Array.isArray(patch)) {
     return patch.map((p) => unixToWin(p));
@@ -39317,7 +39381,7 @@ function isWin(patch) {
   })));
 }
 
-// node_modules/diff/libesm/patch/parse.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/patch/parse.js
 function parsePatch(uniDiff) {
   const diffstr = uniDiff.split(/\n/), list = [];
   let i = 0;
@@ -39422,7 +39486,7 @@ function parsePatch(uniDiff) {
   return list;
 }
 
-// node_modules/diff/libesm/util/distance-iterator.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/util/distance-iterator.js
 function distance_iterator_default(start, minLine, maxLine) {
   let wantForward = true, backwardExhausted = false, forwardExhausted = false, localOffset = 1;
   return function iterator() {
@@ -39451,7 +39515,7 @@ function distance_iterator_default(start, minLine, maxLine) {
   };
 }
 
-// node_modules/diff/libesm/patch/apply.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/patch/apply.js
 function applyPatch(source, patch, options = {}) {
   let patches;
   if (typeof patch === "string") {
@@ -39600,7 +39664,7 @@ function applyStructuredPatch(source, patch, options = {}) {
   return resultLines.join("\n");
 }
 
-// node_modules/diff/libesm/patch/create.js
+// node_modules/.pnpm/diff@8.0.3/node_modules/diff/libesm/patch/create.js
 var INCLUDE_HEADERS = {
   includeIndex: true,
   includeUnderline: true,
@@ -39783,7 +39847,7 @@ function splitLines(text) {
   return result;
 }
 
-// node_modules/@stainless-api/sdk/internal/tslib.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/tslib.mjs
 function __classPrivateFieldSet2(receiver, state, value, kind, f) {
   if (kind === "m")
     throw new TypeError("Private method is not writable");
@@ -39801,7 +39865,7 @@ function __classPrivateFieldGet2(receiver, state, kind, f) {
   return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 }
 
-// node_modules/@stainless-api/sdk/internal/utils/uuid.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/uuid.mjs
 var uuid42 = function() {
   const { crypto: crypto2 } = globalThis;
   if (crypto2?.randomUUID) {
@@ -39813,7 +39877,7 @@ var uuid42 = function() {
   return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) => (+c ^ randomByte() & 15 >> +c / 4).toString(16));
 };
 
-// node_modules/@stainless-api/sdk/internal/errors.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/errors.mjs
 function isAbortError2(err) {
   return typeof err === "object" && err !== null && // Spec-compliant fetch implementations
   ("name" in err && err.name === "AbortError" || // Expo fetch
@@ -39844,7 +39908,7 @@ var castToError2 = (err) => {
   return new Error(err);
 };
 
-// node_modules/@stainless-api/sdk/core/error.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/error.mjs
 var StainlessError = class extends Error {
 };
 var APIError2 = class _APIError extends StainlessError {
@@ -39933,7 +39997,7 @@ var RateLimitError2 = class extends APIError2 {
 var InternalServerError2 = class extends APIError2 {
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/values.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/values.mjs
 var startsWithSchemeRegexp2 = /^[a-z][a-z0-9+.-]*:/i;
 var isAbsoluteURL2 = (url) => {
   return startsWithSchemeRegexp2.test(url);
@@ -39973,13 +40037,13 @@ var safeJSON2 = (text) => {
   }
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/sleep.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/sleep.mjs
 var sleep2 = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-// node_modules/@stainless-api/sdk/version.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/version.mjs
 var VERSION2 = "0.1.0-alpha.19";
 
-// node_modules/@stainless-api/sdk/internal/detect-platform.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/detect-platform.mjs
 function getDetectedPlatform2() {
   if (typeof Deno !== "undefined" && Deno.build != null) {
     return "deno";
@@ -40105,7 +40169,7 @@ var getPlatformHeaders2 = () => {
   return _platformHeaders2 ?? (_platformHeaders2 = getPlatformProperties2());
 };
 
-// node_modules/@stainless-api/sdk/internal/shims.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/shims.mjs
 function getDefaultFetch2() {
   if (typeof fetch !== "undefined") {
     return fetch;
@@ -40150,7 +40214,7 @@ async function CancelReadableStream2(stream) {
   await cancelPromise;
 }
 
-// node_modules/@stainless-api/sdk/internal/request-options.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/request-options.mjs
 var FallbackEncoder2 = ({ headers, body }) => {
   return {
     bodyHeaders: {
@@ -40160,7 +40224,7 @@ var FallbackEncoder2 = ({ headers, body }) => {
   };
 };
 
-// node_modules/@stainless-api/sdk/internal/qs/formats.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/qs/formats.mjs
 var default_format2 = "RFC3986";
 var default_formatter2 = (v) => String(v);
 var formatters2 = {
@@ -40169,7 +40233,7 @@ var formatters2 = {
 };
 var RFC17382 = "RFC1738";
 
-// node_modules/@stainless-api/sdk/internal/qs/utils.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/qs/utils.mjs
 var has2 = (obj, key) => (has2 = Object.hasOwn ?? Function.prototype.call.bind(Object.prototype.hasOwnProperty), has2(obj, key));
 var hex_table2 = /* @__PURE__ */ (() => {
   const array = [];
@@ -40248,7 +40312,7 @@ function maybe_map2(val, fn) {
   return fn(val);
 }
 
-// node_modules/@stainless-api/sdk/internal/qs/stringify.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/qs/stringify.mjs
 var array_prefix_generators2 = {
   brackets(prefix) {
     return String(prefix) + "[]";
@@ -40526,7 +40590,7 @@ function stringify2(object, opts = {}) {
   return joined.length > 0 ? prefix + joined : "";
 }
 
-// node_modules/@stainless-api/sdk/internal/utils/log.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/log.mjs
 var levelNumbers2 = {
   off: 0,
   error: 200,
@@ -40599,7 +40663,7 @@ var formatRequestDetails2 = (details) => {
   return details;
 };
 
-// node_modules/@stainless-api/sdk/internal/parse.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/parse.mjs
 async function defaultParseResponse2(client, props) {
   const { response, requestLogID, retryOfRequestLogID, startTime } = props;
   const body = await (async () => {
@@ -40629,7 +40693,7 @@ async function defaultParseResponse2(client, props) {
   return body;
 }
 
-// node_modules/@stainless-api/sdk/core/api-promise.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/api-promise.mjs
 var _APIPromise_client2;
 var APIPromise2 = class _APIPromise extends Promise {
   constructor(client, responsePromise, parseResponse = defaultParseResponse2) {
@@ -40690,7 +40754,7 @@ var APIPromise2 = class _APIPromise extends Promise {
 };
 _APIPromise_client2 = /* @__PURE__ */ new WeakMap();
 
-// node_modules/@stainless-api/sdk/core/pagination.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/pagination.mjs
 var _AbstractPage_client2;
 var AbstractPage2 = class {
   constructor(client, response, body, options) {
@@ -40771,7 +40835,7 @@ var Page = class extends AbstractPage2 {
   }
 };
 
-// node_modules/@stainless-api/sdk/internal/uploads.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/uploads.mjs
 var checkFileSupport2 = () => {
   if (typeof File === "undefined") {
     const { process: process7 } = globalThis;
@@ -40788,7 +40852,7 @@ function getName2(value) {
 }
 var isAsyncIterable2 = (value) => value != null && typeof value === "object" && typeof value[Symbol.asyncIterator] === "function";
 
-// node_modules/@stainless-api/sdk/internal/to-file.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/to-file.mjs
 var isBlobLike2 = (value) => value != null && typeof value === "object" && typeof value.size === "number" && typeof value.type === "string" && typeof value.text === "function" && typeof value.slice === "function" && typeof value.arrayBuffer === "function";
 var isFileLike2 = (value) => value != null && typeof value === "object" && typeof value.name === "string" && typeof value.lastModified === "number" && isBlobLike2(value);
 var isResponseLike2 = (value) => value != null && typeof value === "object" && typeof value.url === "string" && typeof value.blob === "function";
@@ -40840,14 +40904,14 @@ function propsForError2(value) {
   return `; props: [${props.map((p) => `"${p}"`).join(", ")}]`;
 }
 
-// node_modules/@stainless-api/sdk/core/resource.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/core/resource.mjs
 var APIResource2 = class {
   constructor(client) {
     this._client = client;
   }
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/path.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/path.mjs
 function encodeURIPath2(str) {
   return str.replace(/[^A-Za-z0-9\-._~!$&'()*+,;=:@]+/g, encodeURIComponent);
 }
@@ -40902,7 +40966,7 @@ ${underline}`);
 };
 var path5 = /* @__PURE__ */ createPathTagFunction2(encodeURIPath2);
 
-// node_modules/@stainless-api/sdk/resources/builds/diagnostics.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/builds/diagnostics.mjs
 var Diagnostics = class extends APIResource2 {
   /**
    * Get the list of diagnostics for a given build.
@@ -40918,7 +40982,7 @@ var Diagnostics = class extends APIResource2 {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/builds/target-outputs.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/builds/target-outputs.mjs
 var TargetOutputs = class extends APIResource2 {
   /**
    * Retrieve a method to download an output for a given build target.
@@ -40937,7 +41001,7 @@ var TargetOutputs = class extends APIResource2 {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/builds/builds.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/builds/builds.mjs
 var Builds2 = class extends APIResource2 {
   constructor() {
     super(...arguments);
@@ -40989,7 +41053,7 @@ var Builds2 = class extends APIResource2 {
 Builds2.Diagnostics = Diagnostics;
 Builds2.TargetOutputs = TargetOutputs;
 
-// node_modules/@stainless-api/sdk/resources/orgs.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/orgs.mjs
 var Orgs3 = class extends APIResource2 {
   /**
    * Retrieve an organization by name.
@@ -41005,7 +41069,7 @@ var Orgs3 = class extends APIResource2 {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/projects/branches.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/projects/branches.mjs
 var Branches2 = class extends APIResource2 {
   /**
    * Create a new branch for a project.
@@ -41070,7 +41134,7 @@ var Branches2 = class extends APIResource2 {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/projects/configs.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/projects/configs.mjs
 var Configs = class extends APIResource2 {
   /**
    * Retrieve the configuration files for a given project.
@@ -41088,7 +41152,7 @@ var Configs = class extends APIResource2 {
   }
 };
 
-// node_modules/@stainless-api/sdk/resources/projects/projects.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/resources/projects/projects.mjs
 var Projects = class extends APIResource2 {
   constructor() {
     super(...arguments);
@@ -41125,7 +41189,7 @@ var Projects = class extends APIResource2 {
 Projects.Branches = Branches2;
 Projects.Configs = Configs;
 
-// node_modules/@stainless-api/sdk/internal/headers.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/headers.mjs
 var brand_privateNullableHeaders2 = /* @__PURE__ */ Symbol("brand.privateNullableHeaders");
 function* iterateHeaders2(headers) {
   if (!headers)
@@ -41188,7 +41252,7 @@ var buildHeaders2 = (newHeaders) => {
   return { [brand_privateNullableHeaders2]: true, values: targetHeaders, nulls: nullHeaders };
 };
 
-// node_modules/@stainless-api/sdk/internal/utils/env.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/internal/utils/env.mjs
 var readEnv2 = (env) => {
   if (typeof globalThis.process !== "undefined") {
     return globalThis.process.env?.[env]?.trim() ?? void 0;
@@ -41199,7 +41263,7 @@ var readEnv2 = (env) => {
   return void 0;
 };
 
-// node_modules/@stainless-api/sdk/lib/unwrap.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/lib/unwrap.mjs
 async function unwrapFile(value) {
   if (value === null) {
     return null;
@@ -41211,7 +41275,7 @@ async function unwrapFile(value) {
   return response.text();
 }
 
-// node_modules/@stainless-api/sdk/client.mjs
+// node_modules/.pnpm/@stainless-api+sdk@0.1.0-alpha.19/node_modules/@stainless-api/sdk/client.mjs
 var _Stainless_instances;
 var _a2;
 var _Stainless_encoder;
@@ -41712,18 +41776,23 @@ function wrapAction(actionType, fn) {
   return async () => {
     let stainless;
     let projectName;
+    let orgName;
     try {
-      projectName = getInput("project", { required: true });
+      const projectInput = getInput("project", { required: false }) || void 0;
       const auth = await getStainlessAuth();
-      stainless = getStainlessClient(actionType, {
-        project: projectName,
+      const client = getStainlessClient(actionType, {
         apiKey: auth.key,
         logLevel: "warn",
         fetch: createAutoRefreshFetch(auth, getStainlessAuth)
       });
-      await fn(stainless);
+      const resolved = await resolveProject(client, projectInput);
+      projectName = resolved.projectName;
+      stainless = client.withOptions({ project: projectName });
+      orgName = getInput("org", { required: false }) || resolved.orgName;
+      await fn({ stainless, projectName, orgName });
       await maybeReportResult({
         stainless,
+        orgName,
         projectName,
         actionType,
         successOrError: { result: "success" }
@@ -41733,6 +41802,7 @@ function wrapAction(actionType, fn) {
       if (stainless) {
         await maybeReportResult({
           stainless,
+          orgName,
           projectName,
           actionType,
           successOrError: serializeError(error)
@@ -41753,6 +41823,7 @@ function serializeError(error) {
 }
 async function maybeReportResult({
   stainless,
+  orgName,
   projectName,
   actionType,
   successOrError
@@ -41762,6 +41833,7 @@ async function maybeReportResult({
   }
   try {
     const body = {
+      org: orgName,
       project: projectName,
       build_ids: [...accumulatedBuildIds],
       action_type: actionType,
@@ -42108,9 +42180,9 @@ async function* pollBuild({
 }
 
 // src/preview.ts
-var main = wrapAction("preview", async (stainless) => {
-  const orgName = getInput("org", { required: true });
-  const projectName = getInput("project", { required: true });
+var main = wrapAction("preview", async (ctx) => {
+  const { stainless, projectName } = ctx;
+  const orgName = await resolveOrg(stainless, ctx.orgName);
   const oasPath = getInput("oas_path", { required: false });
   const configPath = getInput("config_path", { required: false });
   const defaultCommitMessage = getInput("commit_message", { required: true });

--- a/merge/action.yml
+++ b/merge/action.yml
@@ -10,11 +10,15 @@ inputs:
       if not provided, requires 'id-token: write' permission). Required for GitLab CI.
     required: false
   org:
-    description: Stainless organization name.
-    required: true
+    description: >-
+      Stainless organization name. If omitted, will be auto-detected from the
+      project.
+    required: false
   project:
-    description: Stainless project name.
-    required: true
+    description: >-
+      Stainless project name. If omitted, will be auto-detected when the API key
+      has access to exactly one project.
+    required: false
   oas_path:
     description: Path to your OpenAPI spec.
     required: false

--- a/preview/action.yml
+++ b/preview/action.yml
@@ -10,11 +10,15 @@ inputs:
       if not provided, requires 'id-token: write' permission). Required for GitLab CI.
     required: false
   org:
-    description: Stainless organization name.
-    required: true
+    description: >-
+      Stainless organization name. If omitted, will be auto-detected from the
+      project.
+    required: false
   project:
-    description: Stainless project name.
-    required: true
+    description: >-
+      Stainless project name. If omitted, will be auto-detected when the API key
+      has access to exactly one project.
+    required: false
   oas_path:
     description: Path to your OpenAPI spec.
     required: true

--- a/src/build.ts
+++ b/src/build.ts
@@ -10,12 +10,12 @@ import { runBuilds } from "./runBuilds";
 import type { RunResult } from "./runBuilds";
 import { wrapAction } from "./wrapAction";
 
-const main = wrapAction("build", async (stainless) => {
+const main = wrapAction("build", async (ctx) => {
+  const { stainless, projectName } = ctx;
   try {
     const oasPath = getInput("oas_path", { required: false }) || undefined;
     const configPath =
       getInput("config_path", { required: false }) || undefined;
-    const projectName = getInput("project", { required: true });
     const commitMessage = makeCommitMessageConventional(
       getInput("commit_message", { required: false }) || undefined,
     );

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -28,13 +28,14 @@ import {
 } from "./config";
 import { logger } from "./logger";
 import { FailRunOn, shouldFailRun } from "./outcomes";
+import { resolveOrg } from "./resolve";
 import type { RunResult } from "./runBuilds";
 import { runBuilds } from "./runBuilds";
 import { wrapAction } from "./wrapAction";
 
-const main = wrapAction("preview", async (stainless) => {
-  const orgName = getInput("org", { required: true });
-  const projectName = getInput("project", { required: true });
+const main = wrapAction("preview", async (ctx) => {
+  const { stainless, projectName } = ctx;
+  const orgName = await resolveOrg(stainless, ctx.orgName);
   const oasPath = getInput("oas_path", { required: false });
   const configPath = getInput("config_path", { required: false });
   const defaultCommitMessage = getInput("commit_message", { required: true });

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,0 +1,48 @@
+import type Stainless from "@stainless-api/sdk";
+import { logger } from "./logger";
+
+export async function resolveProject(
+  client: Stainless,
+  projectInput: string | undefined,
+): Promise<{ projectName: string; orgName: string | undefined }> {
+  if (projectInput) {
+    return { projectName: projectInput, orgName: undefined };
+  }
+
+  const page = await client.projects.list({ limit: 6 });
+  const projects = page.data;
+
+  if (projects.length === 0) {
+    throw new Error(
+      "No projects found for the given API key. Please specify the `project` input explicitly.",
+    );
+  }
+
+  if (projects.length === 1) {
+    const project = projects[0];
+    logger.info(`Auto-detected project: ${project.slug}`);
+    return { projectName: project.slug, orgName: project.org };
+  }
+
+  const slugs = projects
+    .slice(0, 5)
+    .map((p) => p.slug)
+    .join(", ");
+  const suffix = projects.length > 5 ? ", ..." : "";
+  throw new Error(
+    `Multiple projects found: ${slugs}${suffix}. Please specify the \`project\` input explicitly.`,
+  );
+}
+
+export async function resolveOrg(
+  client: Stainless,
+  orgName: string | undefined,
+): Promise<string> {
+  if (orgName) {
+    return orgName;
+  }
+
+  const project = await client.projects.retrieve();
+  logger.info(`Auto-detected org: ${project.org}`);
+  return project.org;
+}


### PR DESCRIPTION
we want to be more flexible with project renames, especially for new projects. specifically to make onboarding flows work, let's allow auto-detection of orgs and projects.

eventually we might want to do something of the form "create the project if it doesn't exist"?