### PR TITLE
feat: use severity as conclusion for diagnostic/check step cases

### DIFF
--- a/dist/merge.js
+++ b/dist/merge.js
@@ -15853,7 +15853,7 @@ function categorizeOutcome({
     )[0];
     return {
       isPending: false,
-      conclusion: headConclusion,
+      conclusion: worstOutcome.severity,
       ...worstOutcome
     };
   }

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -15853,7 +15853,7 @@ function categorizeOutcome({
     )[0];
     return {
       isPending: false,
-      conclusion: headConclusion,
+      conclusion: worstOutcome.severity,
       ...worstOutcome
     };
   }

--- a/src/outcomes.ts
+++ b/src/outcomes.ts
@@ -218,7 +218,7 @@ export function categorizeOutcome({
 
     return {
       isPending: false,
-      conclusion: headConclusion,
+      conclusion: worstOutcome.severity,
       ...worstOutcome,
     };
   }


### PR DESCRIPTION
this is better than using the raw conclusion, since if we regress in a diagnostics or a check step we want to treat it like a warning/error