### PR TITLE
feat: show construction sign for non-regressing fatal error

### DIFF
--- a/dist/build.js
+++ b/dist/build.js
@@ -27072,6 +27072,7 @@ var fs6 = __toESM(require("node:fs"));
 var import_ts_dedent = __toESM(require_dist2());
 var Symbol2 = {
   Bulb: "\u{1F4A1}",
+  Construction: "\u{1F6A7}",
   Exclamation: "\u2757",
   Eyes: "\u{1F440}",
   GreenSquare: "\u{1F7E9}",
@@ -27527,7 +27528,7 @@ function Result({
       };
     }
     return {
-      ResultIcon: Symbol2.WhiteCheckMark,
+      ResultIcon: severity === "fatal" ? Symbol2.Construction : Symbol2.WhiteCheckMark,
       Description: Italic(reason)
     };
   })();

--- a/dist/merge.js
+++ b/dist/merge.js
@@ -16127,6 +16127,7 @@ function makeCommitMessageConventional(message) {
 var import_ts_dedent = __toESM(require_dist());
 var Symbol2 = {
   Bulb: "\u{1F4A1}",
+  Construction: "\u{1F6A7}",
   Exclamation: "\u2757",
   Eyes: "\u{1F440}",
   GreenSquare: "\u{1F7E9}",
@@ -16582,7 +16583,7 @@ function Result({
       };
     }
     return {
-      ResultIcon: Symbol2.WhiteCheckMark,
+      ResultIcon: severity === "fatal" ? Symbol2.Construction : Symbol2.WhiteCheckMark,
       Description: Italic(reason)
     };
   })();

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -16358,6 +16358,7 @@ function makeCommitMessageConventional(message) {
 var import_ts_dedent = __toESM(require_dist());
 var Symbol2 = {
   Bulb: "\u{1F4A1}",
+  Construction: "\u{1F6A7}",
   Exclamation: "\u2757",
   Eyes: "\u{1F440}",
   GreenSquare: "\u{1F7E9}",
@@ -16582,7 +16583,7 @@ function Result({
       };
     }
     return {
-      ResultIcon: Symbol2.WhiteCheckMark,
+      ResultIcon: severity === "fatal" ? Symbol2.Construction : Symbol2.WhiteCheckMark,
       Description: Italic(reason)
     };
   })();

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -254,7 +254,10 @@ function Result({
       };
     }
     return {
-      ResultIcon: MD.Symbol.WhiteCheckMark,
+      ResultIcon:
+        severity === "fatal"
+          ? MD.Symbol.Construction
+          : MD.Symbol.WhiteCheckMark,
       Description: MD.Italic(reason),
     };
   })();

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -2,6 +2,7 @@ import { dedent as tsdedent } from "ts-dedent";
 
 export const Symbol = {
   Bulb: "💡",
+  Construction: "🚧",
   Exclamation: "❗",
   Eyes: "👀",
   GreenSquare: "🟩",


### PR DESCRIPTION
non-regressing fatal errors are tricky because while you do not want to block CI for a pre-existing issue, they may mask other regressions. so as a compromise, we'll show a 🚧 emoji in that case