### PR TITLE
chore: always pass logLevel warn to the SDK clients

### DIFF
--- a/dist/build.js
+++ b/dist/build.js
@@ -22452,7 +22452,7 @@ var GitHubClient = class {
       owner: getGitHubContext().owner,
       repo: getGitHubContext().repo,
       resources: [BaseCommits, BaseComments2, BasePulls],
-      logLevel: getInput("log_level", { required: false }) ?? "warn",
+      logLevel: "warn",
       logger
     });
   }
@@ -25083,7 +25083,7 @@ var GitLabClient = class {
       apiToken: token,
       baseURL: getGitLabContext().urls.api,
       resources: [BaseCommits3, BaseMergeRequests, BaseNotes2],
-      logLevel: getInput("log_level", { required: false }) ?? "warn",
+      logLevel: "warn",
       logger
     });
   }
@@ -26602,7 +26602,7 @@ function wrapAction(actionType, fn) {
       stainless = getStainlessClient(actionType, {
         project: projectName,
         apiKey: auth.key,
-        logLevel: getInput("log_level", { required: false }) ?? "warn",
+        logLevel: "warn",
         logger,
         fetch: createAutoRefreshFetch(auth, getStainlessAuth)
       });

--- a/dist/merge.js
+++ b/dist/merge.js
@@ -13271,7 +13271,7 @@ var GitHubClient = class {
       owner: getGitHubContext().owner,
       repo: getGitHubContext().repo,
       resources: [BaseCommits, BaseComments2, BasePulls],
-      logLevel: getInput("log_level", { required: false }) ?? "warn",
+      logLevel: "warn",
       logger
     });
   }
@@ -15902,7 +15902,7 @@ var GitLabClient = class {
       apiToken: token,
       baseURL: getGitLabContext().urls.api,
       resources: [BaseCommits3, BaseMergeRequests, BaseNotes2],
-      logLevel: getInput("log_level", { required: false }) ?? "warn",
+      logLevel: "warn",
       logger
     });
   }
@@ -19981,7 +19981,7 @@ function wrapAction(actionType, fn) {
       stainless = getStainlessClient(actionType, {
         project: projectName,
         apiKey: auth.key,
-        logLevel: getInput("log_level", { required: false }) ?? "warn",
+        logLevel: "warn",
         logger,
         fetch: createAutoRefreshFetch(auth, getStainlessAuth)
       });

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -13271,7 +13271,7 @@ var GitHubClient = class {
       owner: getGitHubContext().owner,
       repo: getGitHubContext().repo,
       resources: [BaseCommits, BaseComments2, BasePulls],
-      logLevel: getInput("log_level", { required: false }) ?? "warn",
+      logLevel: "warn",
       logger
     });
   }
@@ -15902,7 +15902,7 @@ var GitLabClient = class {
       apiToken: token,
       baseURL: getGitLabContext().urls.api,
       resources: [BaseCommits3, BaseMergeRequests, BaseNotes2],
-      logLevel: getInput("log_level", { required: false }) ?? "warn",
+      logLevel: "warn",
       logger
     });
   }
@@ -20048,7 +20048,7 @@ function wrapAction(actionType, fn) {
       stainless = getStainlessClient(actionType, {
         project: projectName,
         apiKey: auth.key,
-        logLevel: getInput("log_level", { required: false }) ?? "warn",
+        logLevel: "warn",
         logger,
         fetch: createAutoRefreshFetch(auth, getStainlessAuth)
       });

--- a/src/compat/github/api.ts
+++ b/src/compat/github/api.ts
@@ -10,7 +10,6 @@ import { logger } from "../../logger";
 import type { APIClient, Comment, PullRequest } from "../api";
 import { getInput } from "../input";
 import { getGitHubContext as ctx } from "./context";
-import { LogLevel } from "@stainless-api/github-internal/client";
 
 class GitHubClient implements APIClient {
   private client: PartialGitHub<{
@@ -28,8 +27,7 @@ class GitHubClient implements APIClient {
       owner: ctx().owner,
       repo: ctx().repo,
       resources: [BaseCommits, BaseComments, BasePulls],
-      logLevel: (getInput("log_level", { required: false }) ??
-        "warn") as LogLevel,
+      logLevel: "warn",
       logger,
     });
   }

--- a/src/compat/gitlab/api.ts
+++ b/src/compat/gitlab/api.ts
@@ -15,7 +15,6 @@ import { logger } from "../../logger";
 import type { APIClient, Comment, PullRequest } from "../api";
 import { getInput } from "../input";
 import { getGitLabContext as ctx } from "./context";
-import { LogLevel } from "@stainless-api/gitlab-internal/client";
 
 class GitLabClient implements APIClient {
   private client: PartialGitLab<{
@@ -30,8 +29,7 @@ class GitLabClient implements APIClient {
       apiToken: token,
       baseURL: ctx().urls.api,
       resources: [BaseCommits, BaseMergeRequests, BaseNotes],
-      logLevel: (getInput("log_level", { required: false }) ??
-        "warn") as LogLevel,
+      logLevel: "warn",
       logger,
     });
   }

--- a/src/wrapAction.ts
+++ b/src/wrapAction.ts
@@ -3,7 +3,6 @@ import { getInput } from "./compat/input";
 import { getStainlessAuth } from "./compat";
 import { createAutoRefreshFetch, getStainlessClient } from "./stainless";
 import { logger } from "./logger";
-import { LogLevel } from "@stainless-api/sdk/client";
 
 const accumulatedBuildIds = new Set<string>();
 
@@ -32,8 +31,7 @@ export function wrapAction(
       stainless = getStainlessClient(actionType, {
         project: projectName,
         apiKey: auth.key,
-        logLevel: (getInput("log_level", { required: false }) ??
-          "warn") as LogLevel,
+        logLevel: "warn",
         logger,
         fetch: createAutoRefreshFetch(auth, getStainlessAuth),
       });


### PR DESCRIPTION
do not thread through since the client logs are too noisy