### PR TITLE
fix: slightly different polling termination condition

### DIFF
--- a/dist/build.js
+++ b/dist/build.js
@@ -27155,7 +27155,9 @@ async function* pollBuild({
     return;
   }
   const pollingStart = Date.now();
-  while (Object.values(outcomes).length < languages.length || Object.values(outcomes).some((outcome) => categorizeOutcome({ outcome }).isPending) && Date.now() - pollingStart < maxPollingSeconds * 1e3) {
+  while ((Object.values(outcomes).length < languages.length || Object.values(outcomes).some(
+    (outcome) => categorizeOutcome({ outcome }).isPending
+  )) && Date.now() - pollingStart < maxPollingSeconds * 1e3) {
     let hasChange = false;
     const build2 = await stainless.builds.retrieve(buildId);
     for (const language of languages) {

--- a/dist/merge.js
+++ b/dist/merge.js
@@ -20294,7 +20294,9 @@ async function* pollBuild({
     return;
   }
   const pollingStart = Date.now();
-  while (Object.values(outcomes).length < languages.length || Object.values(outcomes).some((outcome) => categorizeOutcome({ outcome }).isPending) && Date.now() - pollingStart < maxPollingSeconds * 1e3) {
+  while ((Object.values(outcomes).length < languages.length || Object.values(outcomes).some(
+    (outcome) => categorizeOutcome({ outcome }).isPending
+  )) && Date.now() - pollingStart < maxPollingSeconds * 1e3) {
     let hasChange = false;
     const build2 = await stainless.builds.retrieve(buildId);
     for (const language of languages) {

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -20361,7 +20361,9 @@ async function* pollBuild({
     return;
   }
   const pollingStart = Date.now();
-  while (Object.values(outcomes).length < languages.length || Object.values(outcomes).some((outcome) => categorizeOutcome({ outcome }).isPending) && Date.now() - pollingStart < maxPollingSeconds * 1e3) {
+  while ((Object.values(outcomes).length < languages.length || Object.values(outcomes).some(
+    (outcome) => categorizeOutcome({ outcome }).isPending
+  )) && Date.now() - pollingStart < maxPollingSeconds * 1e3) {
     let hasChange = false;
     const build2 = await stainless.builds.retrieve(buildId);
     for (const language of languages) {

--- a/src/runBuilds.ts
+++ b/src/runBuilds.ts
@@ -339,11 +339,11 @@ async function* pollBuild({
 
   const pollingStart = Date.now();
   while (
-    Object.values(outcomes).length < languages.length ||
-    (Object.values(outcomes).some(
-      (outcome) => categorizeOutcome({ outcome }).isPending,
-    ) &&
-      Date.now() - pollingStart < maxPollingSeconds * 1000)
+    (Object.values(outcomes).length < languages.length ||
+      Object.values(outcomes).some(
+        (outcome) => categorizeOutcome({ outcome }).isPending,
+      )) &&
+    Date.now() - pollingStart < maxPollingSeconds * 1000
   ) {
     let hasChange = false;
     const build = await stainless.builds.retrieve(buildId);


### PR DESCRIPTION
use pending outcome rather than completion status, to consolidate our logic about what constitutes "pending", should be a noop for public-facing behavior, slight change for internal behavior where we don't wait for postgen if there's no diff