### PR TITLE
fix: catch guesser errors

### DIFF
--- a/dist/build.js
+++ b/dist/build.js
@@ -26995,20 +26995,24 @@ async function* runBuilds({
     const hasBaseBranch = !!baseBranch && !!await stainless.projects.branches.retrieve(baseBranch).catch(() => null);
     if (guessConfig) {
       logger.debug("Guessing config before branch reset");
-      if (hasBranch) {
-        configContent = Object.values(
-          await stainless.projects.configs.guess({
-            branch,
-            spec: oasContent
-          })
-        )[0]?.content;
-      } else {
-        configContent = Object.values(
-          await stainless.projects.configs.guess({
-            branch: branchFrom,
-            spec: oasContent
-          })
-        )[0]?.content;
+      try {
+        if (hasBranch) {
+          configContent = Object.values(
+            await stainless.projects.configs.guess({
+              branch,
+              spec: oasContent
+            })
+          )[0]?.content;
+        } else {
+          configContent = Object.values(
+            await stainless.projects.configs.guess({
+              branch: branchFrom,
+              spec: oasContent
+            })
+          )[0]?.content;
+        }
+      } catch (e) {
+        logger.warn("Error guessing config, continuing anyways", e);
       }
     } else if (hasBranch && hasBaseBranch) {
       logger.debug("Computing config patch before branch reset");

--- a/dist/merge.js
+++ b/dist/merge.js
@@ -20134,20 +20134,24 @@ async function* runBuilds({
     const hasBaseBranch = !!baseBranch && !!await stainless.projects.branches.retrieve(baseBranch).catch(() => null);
     if (guessConfig) {
       logger.debug("Guessing config before branch reset");
-      if (hasBranch) {
-        configContent = Object.values(
-          await stainless.projects.configs.guess({
-            branch,
-            spec: oasContent
-          })
-        )[0]?.content;
-      } else {
-        configContent = Object.values(
-          await stainless.projects.configs.guess({
-            branch: branchFrom,
-            spec: oasContent
-          })
-        )[0]?.content;
+      try {
+        if (hasBranch) {
+          configContent = Object.values(
+            await stainless.projects.configs.guess({
+              branch,
+              spec: oasContent
+            })
+          )[0]?.content;
+        } else {
+          configContent = Object.values(
+            await stainless.projects.configs.guess({
+              branch: branchFrom,
+              spec: oasContent
+            })
+          )[0]?.content;
+        }
+      } catch (e) {
+        logger.warn("Error guessing config, continuing anyways", e);
       }
     } else if (hasBranch && hasBaseBranch) {
       logger.debug("Computing config patch before branch reset");

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -20201,20 +20201,24 @@ async function* runBuilds({
     const hasBaseBranch = !!baseBranch && !!await stainless.projects.branches.retrieve(baseBranch).catch(() => null);
     if (guessConfig) {
       logger.debug("Guessing config before branch reset");
-      if (hasBranch) {
-        configContent = Object.values(
-          await stainless.projects.configs.guess({
-            branch,
-            spec: oasContent
-          })
-        )[0]?.content;
-      } else {
-        configContent = Object.values(
-          await stainless.projects.configs.guess({
-            branch: branchFrom,
-            spec: oasContent
-          })
-        )[0]?.content;
+      try {
+        if (hasBranch) {
+          configContent = Object.values(
+            await stainless.projects.configs.guess({
+              branch,
+              spec: oasContent
+            })
+          )[0]?.content;
+        } else {
+          configContent = Object.values(
+            await stainless.projects.configs.guess({
+              branch: branchFrom,
+              spec: oasContent
+            })
+          )[0]?.content;
+        }
+      } catch (e) {
+        logger.warn("Error guessing config, continuing anyways", e);
       }
     } else if (hasBranch && hasBaseBranch) {
       logger.debug("Computing config patch before branch reset");

--- a/src/runBuilds.ts
+++ b/src/runBuilds.ts
@@ -121,20 +121,24 @@ export async function* runBuilds({
       logger.debug("Guessing config before branch reset");
       // If the `branch` already exists, we should guess against it, in case
       // there were changes made via the studio.
-      if (hasBranch) {
-        configContent = Object.values(
-          await stainless.projects.configs.guess({
-            branch,
-            spec: oasContent!,
-          }),
-        )[0]?.content;
-      } else {
-        configContent = Object.values(
-          await stainless.projects.configs.guess({
-            branch: branchFrom,
-            spec: oasContent!,
-          }),
-        )[0]?.content;
+      try {
+        if (hasBranch) {
+          configContent = Object.values(
+            await stainless.projects.configs.guess({
+              branch,
+              spec: oasContent!,
+            }),
+          )[0]?.content;
+        } else {
+          configContent = Object.values(
+            await stainless.projects.configs.guess({
+              branch: branchFrom,
+              spec: oasContent!,
+            }),
+          )[0]?.content;
+        }
+      } catch (e) {
+        logger.warn("Error guessing config, continuing anyways", e);
       }
     } else if (hasBranch && hasBaseBranch) {
       logger.debug("Computing config patch before branch reset");


### PR DESCRIPTION
making a change on our server side to be more aggressive about throwing rather than failing silently - but we can still fail silently on the client, since guesser errors shouldn't block the user