### PR TITLE
fix: sort regressions first when determining worst outcome

### DIFF
--- a/dist/build.js
+++ b/dist/build.js
@@ -26656,8 +26656,8 @@ function categorizeOutcome({
       checkFailureOutcome
     ].filter((r) => r !== null).sort(
       (a, b) => (
-        // sort by severity then rank
-        conclusions.diagnostic.indexOf(a.severity) - conclusions.diagnostic.indexOf(b.severity) || a.rank - b.rank
+        // sort by regression status then severity then rank
+        (!(a.severity === "fatal" || b.severity === "fatal") ? [true, null, false].indexOf(a.isRegression) - [true, null, false].indexOf(b.isRegression) : 0) || conclusions.diagnostic.indexOf(a.severity) - conclusions.diagnostic.indexOf(b.severity) || a.rank - b.rank
       )
     )[0];
     return {

--- a/dist/merge.js
+++ b/dist/merge.js
@@ -16331,8 +16331,8 @@ function categorizeOutcome({
       checkFailureOutcome
     ].filter((r) => r !== null).sort(
       (a, b) => (
-        // sort by severity then rank
-        conclusions.diagnostic.indexOf(a.severity) - conclusions.diagnostic.indexOf(b.severity) || a.rank - b.rank
+        // sort by regression status then severity then rank
+        (!(a.severity === "fatal" || b.severity === "fatal") ? [true, null, false].indexOf(a.isRegression) - [true, null, false].indexOf(b.isRegression) : 0) || conclusions.diagnostic.indexOf(a.severity) - conclusions.diagnostic.indexOf(b.severity) || a.rank - b.rank
       )
     )[0];
     return {

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -16251,8 +16251,8 @@ function categorizeOutcome({
       checkFailureOutcome
     ].filter((r) => r !== null).sort(
       (a, b) => (
-        // sort by severity then rank
-        conclusions.diagnostic.indexOf(a.severity) - conclusions.diagnostic.indexOf(b.severity) || a.rank - b.rank
+        // sort by regression status then severity then rank
+        (!(a.severity === "fatal" || b.severity === "fatal") ? [true, null, false].indexOf(a.isRegression) - [true, null, false].indexOf(b.isRegression) : 0) || conclusions.diagnostic.indexOf(a.severity) - conclusions.diagnostic.indexOf(b.severity) || a.rank - b.rank
       )
     )[0];
     return {

--- a/src/outcomes.ts
+++ b/src/outcomes.ts
@@ -232,9 +232,14 @@ export function categorizeOutcome({
       .filter((r): r is Exclude<typeof categoryOutcome, null> => r !== null)
       .sort(
         (a, b) =>
-          // sort by severity then rank
+          // sort by regression status then severity then rank
+          (!(a.severity === "fatal" || b.severity === "fatal")
+            ? [true, null, false].indexOf(a.isRegression) -
+              [true, null, false].indexOf(b.isRegression)
+            : 0) ||
           conclusions.diagnostic.indexOf(a.severity) -
-            conclusions.diagnostic.indexOf(b.severity) || a.rank - b.rank,
+            conclusions.diagnostic.indexOf(b.severity) ||
+          a.rank - b.rank,
       )[0];
 
     return {


### PR DESCRIPTION
we should generally consider regression cases worse than non-regression cases when determining top-level outcome. the exception is fatal cases, which are always worse than anything else.