### PR TITLE
fix: disambiguate project name in comment title

### DIFF
--- a/dist/build.js
+++ b/dist/build.js
@@ -27419,8 +27419,8 @@ var Link = ({ text, href }) => `<a href="${href}">${text}</a>`;
 var Rule = () => `<hr />`;
 
 // src/comment.ts
-var COMMENT_TITLE = Heading(
-  `${Symbol2.HeavyAsterisk} Stainless preview builds`
+var COMMENT_TITLE = (projectName) => Heading(
+  `${Symbol2.HeavyAsterisk} Stainless preview builds${projectName ? ` for ${projectName}` : ""}`
 );
 var COMMENT_FOOTER_DIVIDER = Comment("stainless-preview-footer");
 function printComment({
@@ -27459,7 +27459,7 @@ function printComment({
   })();
   const dateString = (/* @__PURE__ */ new Date()).toISOString().replace("T", " ").replace(/\.\d+Z$/, " UTC");
   const fullComment = Dedent`
-    ${COMMENT_TITLE}
+    ${COMMENT_TITLE(projectName)}
 
     ${Blocks4}
 
@@ -27794,11 +27794,11 @@ function parseCommitMessages(body) {
   const message = body?.match(/(?<!\\)```([\s\S]*?)(?<!\\)```/)?.[1].trim();
   return message ? { commitMessage: makeCommitMessageConventional(message) } : {};
 }
-async function retrieveComment(prNumber) {
+async function retrieveComment(prNumber, projectName) {
   const comments = await api().listComments(prNumber);
-  const existingComment = comments.find(
-    (comment) => comment.body?.includes(COMMENT_TITLE)
-  );
+  const existingComment = comments.find((comment) => comment.body?.includes(COMMENT_TITLE(projectName)) || // backwards compatibility for comments that don't include the project name
+  // TODO: remove this fallback eventually
+  !comment.body?.includes(COMMENT_TITLE(null) + " for") && comment.body?.includes(COMMENT_TITLE(null)));
   if (!existingComment) {
     return null;
   }
@@ -27911,7 +27911,7 @@ async function runMerge(stainless, params) {
     logger.info("No config files changed, skipping merge");
     return;
   }
-  const comment = makeComment && prNumber ? await retrieveComment(prNumber) : null;
+  const comment = makeComment && prNumber ? await retrieveComment(prNumber, projectName) : null;
   const commitMessage = comment?.commitMessage ?? makeCommitMessageConventional(defaultCommitMessage);
   const targetCommitMessages = multipleCommitMessages ? comment?.targetCommitMessages ?? {} : void 0;
   if (targetCommitMessages) {
@@ -28047,7 +28047,7 @@ async function runPreview(stainless, params) {
     logger.info("No config files changed, skipping preview");
     if (makeComment) {
       logger.group("Updating comment");
-      const commentBody = printComment({ noChanges: true });
+      const commentBody = printComment({ noChanges: true, projectName });
       await upsertComment(prNumber, {
         body: commentBody,
         skipCreate: true
@@ -28065,7 +28065,7 @@ async function runPreview(stainless, params) {
     configPath
   });
   logger.groupEnd();
-  const initialComment = makeComment ? await retrieveComment(prNumber) : null;
+  const initialComment = makeComment ? await retrieveComment(prNumber, projectName) : null;
   let commitMessage = initialComment?.commitMessage ?? makeCommitMessageConventional(defaultCommitMessage);
   let targetCommitMessages = multipleCommitMessages ? initialComment?.targetCommitMessages ?? {} : void 0;
   if (targetCommitMessages) {
@@ -28099,7 +28099,7 @@ async function runPreview(stainless, params) {
     }
     if (makeComment && latestRun) {
       const { outcomes, baseOutcomes } = latestRun;
-      const comment = await retrieveComment(prNumber);
+      const comment = await retrieveComment(prNumber, projectName);
       commitMessage = comment?.commitMessage ?? commitMessage;
       targetCommitMessages = comment?.targetCommitMessages ?? targetCommitMessages;
       if (shouldGenerateAiCommitMessages) {

--- a/dist/merge.js
+++ b/dist/merge.js
@@ -18333,8 +18333,8 @@ function getNewChecks(headChecks, baseChecks) {
 }
 
 // src/comment.ts
-var COMMENT_TITLE = Heading(
-  `${Symbol2.HeavyAsterisk} Stainless preview builds`
+var COMMENT_TITLE = (projectName) => Heading(
+  `${Symbol2.HeavyAsterisk} Stainless preview builds${projectName ? ` for ${projectName}` : ""}`
 );
 var COMMENT_FOOTER_DIVIDER = Comment("stainless-preview-footer");
 function printComment({
@@ -18373,7 +18373,7 @@ function printComment({
   })();
   const dateString = (/* @__PURE__ */ new Date()).toISOString().replace("T", " ").replace(/\.\d+Z$/, " UTC");
   const fullComment = Dedent`
-    ${COMMENT_TITLE}
+    ${COMMENT_TITLE(projectName)}
 
     ${Blocks4}
 
@@ -18708,11 +18708,11 @@ function parseCommitMessages(body) {
   const message = body?.match(/(?<!\\)```([\s\S]*?)(?<!\\)```/)?.[1].trim();
   return message ? { commitMessage: makeCommitMessageConventional(message) } : {};
 }
-async function retrieveComment(prNumber) {
+async function retrieveComment(prNumber, projectName) {
   const comments = await api().listComments(prNumber);
-  const existingComment = comments.find(
-    (comment) => comment.body?.includes(COMMENT_TITLE)
-  );
+  const existingComment = comments.find((comment) => comment.body?.includes(COMMENT_TITLE(projectName)) || // backwards compatibility for comments that don't include the project name
+  // TODO: remove this fallback eventually
+  !comment.body?.includes(COMMENT_TITLE(null) + " for") && comment.body?.includes(COMMENT_TITLE(null)));
   if (!existingComment) {
     return null;
   }
@@ -20490,7 +20490,7 @@ async function runMerge(stainless, params) {
     logger.info("No config files changed, skipping merge");
     return;
   }
-  const comment = makeComment && prNumber ? await retrieveComment(prNumber) : null;
+  const comment = makeComment && prNumber ? await retrieveComment(prNumber, projectName) : null;
   const commitMessage = comment?.commitMessage ?? makeCommitMessageConventional(defaultCommitMessage);
   const targetCommitMessages = multipleCommitMessages ? comment?.targetCommitMessages ?? {} : void 0;
   if (targetCommitMessages) {

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -18333,8 +18333,8 @@ var Link = ({ text, href }) => `<a href="${href}">${text}</a>`;
 var Rule = () => `<hr />`;
 
 // src/comment.ts
-var COMMENT_TITLE = Heading(
-  `${Symbol2.HeavyAsterisk} Stainless preview builds`
+var COMMENT_TITLE = (projectName) => Heading(
+  `${Symbol2.HeavyAsterisk} Stainless preview builds${projectName ? ` for ${projectName}` : ""}`
 );
 var COMMENT_FOOTER_DIVIDER = Comment("stainless-preview-footer");
 function printComment({
@@ -18373,7 +18373,7 @@ function printComment({
   })();
   const dateString = (/* @__PURE__ */ new Date()).toISOString().replace("T", " ").replace(/\.\d+Z$/, " UTC");
   const fullComment = Dedent`
-    ${COMMENT_TITLE}
+    ${COMMENT_TITLE(projectName)}
 
     ${Blocks4}
 
@@ -18708,11 +18708,11 @@ function parseCommitMessages(body) {
   const message = body?.match(/(?<!\\)```([\s\S]*?)(?<!\\)```/)?.[1].trim();
   return message ? { commitMessage: makeCommitMessageConventional(message) } : {};
 }
-async function retrieveComment(prNumber) {
+async function retrieveComment(prNumber, projectName) {
   const comments = await api().listComments(prNumber);
-  const existingComment = comments.find(
-    (comment) => comment.body?.includes(COMMENT_TITLE)
-  );
+  const existingComment = comments.find((comment) => comment.body?.includes(COMMENT_TITLE(projectName)) || // backwards compatibility for comments that don't include the project name
+  // TODO: remove this fallback eventually
+  !comment.body?.includes(COMMENT_TITLE(null) + " for") && comment.body?.includes(COMMENT_TITLE(null)));
   if (!existingComment) {
     return null;
   }
@@ -20563,7 +20563,7 @@ async function runPreview(stainless, params) {
     logger.info("No config files changed, skipping preview");
     if (makeComment) {
       logger.group("Updating comment");
-      const commentBody = printComment({ noChanges: true });
+      const commentBody = printComment({ noChanges: true, projectName });
       await upsertComment(prNumber, {
         body: commentBody,
         skipCreate: true
@@ -20581,7 +20581,7 @@ async function runPreview(stainless, params) {
     configPath
   });
   logger.groupEnd();
-  const initialComment = makeComment ? await retrieveComment(prNumber) : null;
+  const initialComment = makeComment ? await retrieveComment(prNumber, projectName) : null;
   let commitMessage = initialComment?.commitMessage ?? makeCommitMessageConventional(defaultCommitMessage);
   let targetCommitMessages = multipleCommitMessages ? initialComment?.targetCommitMessages ?? {} : void 0;
   if (targetCommitMessages) {
@@ -20615,7 +20615,7 @@ async function runPreview(stainless, params) {
     }
     if (makeComment && latestRun) {
       const { outcomes, baseOutcomes } = latestRun;
-      const comment = await retrieveComment(prNumber);
+      const comment = await retrieveComment(prNumber, projectName);
       commitMessage = comment?.commitMessage ?? commitMessage;
       targetCommitMessages = comment?.targetCommitMessages ?? targetCommitMessages;
       if (shouldGenerateAiCommitMessages) {

--- a/src/__snapshots__/comment.test.ts.snap
+++ b/src/__snapshots__/comment.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`printComment > should print comment 1`] = `
-"<h3>✱ Stainless preview builds</h3>
+"<h3>✱ Stainless preview builds for test-project</h3>
 
 This PR will update the <code>test-project</code> SDKs with the following commit message.
 

--- a/src/comment.test.ts
+++ b/src/comment.test.ts
@@ -17,7 +17,8 @@ describe("printComment", () => {
   });
 
   it("should print no changes comment", () => {
-    expect(printComment({ noChanges: true, projectName: 'fake project' })).toMatchInlineSnapshot(`
+    expect(printComment({ noChanges: true, projectName: "fake project" }))
+      .toMatchInlineSnapshot(`
       "<h3>✱ Stainless preview builds for fake project</h3>
 
       No changes were made to the SDKs.

--- a/src/comment.test.ts
+++ b/src/comment.test.ts
@@ -17,8 +17,8 @@ describe("printComment", () => {
   });
 
   it("should print no changes comment", () => {
-    expect(printComment({ noChanges: true })).toMatchInlineSnapshot(`
-      "<h3>✱ Stainless preview builds</h3>
+    expect(printComment({ noChanges: true, projectName: 'fake project' })).toMatchInlineSnapshot(`
+      "<h3>✱ Stainless preview builds for fake project</h3>
 
       No changes were made to the SDKs.
 

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -11,8 +11,8 @@ import {
   sortDiagnostics,
 } from "./outcomes";
 
-const COMMENT_TITLE = MD.Heading(
-  `${MD.Symbol.HeavyAsterisk} Stainless preview builds`,
+const COMMENT_TITLE = (projectName: string | null) => MD.Heading(
+  `${MD.Symbol.HeavyAsterisk} Stainless preview builds${projectName ? ` for ${projectName}` : ""}`,
 );
 
 const COMMENT_FOOTER_DIVIDER = MD.Comment("stainless-preview-footer");
@@ -41,8 +41,8 @@ export function printComment({
   outcomes,
 }:
   | ({ noChanges?: never } & Omit<PrintCommentOptions, "noChanges">)
-  | ({ noChanges: true } & {
-      [K in keyof Omit<PrintCommentOptions, "noChanges">]?: never;
+  | ({ noChanges: true; projectName: string } & {
+      [K in keyof Omit<Omit<PrintCommentOptions, "noChanges">, "projectName">]?: never;
     })) {
   const Blocks = (() => {
     if (noChanges) {
@@ -84,7 +84,7 @@ export function printComment({
     .replace(/\.\d+Z$/, " UTC");
 
   const fullComment = MD.Dedent`
-    ${COMMENT_TITLE}
+    ${COMMENT_TITLE(projectName)}
 
     ${Blocks}
 
@@ -564,12 +564,15 @@ export function parseCommitMessages(body?: string | null): {
     : {};
 }
 
-export async function retrieveComment(prNumber: number) {
+export async function retrieveComment(prNumber: number, projectName: string) {
   const comments = await api().listComments(prNumber);
 
   const existingComment = comments.find((comment) =>
-    comment.body?.includes(COMMENT_TITLE),
-  );
+    comment.body?.includes(COMMENT_TITLE(projectName)) || (
+    // backwards compatibility for comments that don't include the project name
+    // TODO: remove this fallback eventually
+      !comment.body?.includes(COMMENT_TITLE(null) + ' for') && comment.body?.includes(COMMENT_TITLE(null))
+  ));
 
   if (!existingComment) {
     return null;

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -11,9 +11,10 @@ import {
   sortDiagnostics,
 } from "./outcomes";
 
-const COMMENT_TITLE = (projectName: string | null) => MD.Heading(
-  `${MD.Symbol.HeavyAsterisk} Stainless preview builds${projectName ? ` for ${projectName}` : ""}`,
-);
+const COMMENT_TITLE = (projectName: string | null) =>
+  MD.Heading(
+    `${MD.Symbol.HeavyAsterisk} Stainless preview builds${projectName ? ` for ${projectName}` : ""}`,
+  );
 
 const COMMENT_FOOTER_DIVIDER = MD.Comment("stainless-preview-footer");
 
@@ -42,7 +43,10 @@ export function printComment({
 }:
   | ({ noChanges?: never } & Omit<PrintCommentOptions, "noChanges">)
   | ({ noChanges: true; projectName: string } & {
-      [K in keyof Omit<Omit<PrintCommentOptions, "noChanges">, "projectName">]?: never;
+      [K in keyof Omit<
+        Omit<PrintCommentOptions, "noChanges">,
+        "projectName"
+      >]?: never;
     })) {
   const Blocks = (() => {
     if (noChanges) {
@@ -567,12 +571,14 @@ export function parseCommitMessages(body?: string | null): {
 export async function retrieveComment(prNumber: number, projectName: string) {
   const comments = await api().listComments(prNumber);
 
-  const existingComment = comments.find((comment) =>
-    comment.body?.includes(COMMENT_TITLE(projectName)) || (
-    // backwards compatibility for comments that don't include the project name
-    // TODO: remove this fallback eventually
-      !comment.body?.includes(COMMENT_TITLE(null) + ' for') && comment.body?.includes(COMMENT_TITLE(null))
-  ));
+  const existingComment = comments.find(
+    (comment) =>
+      comment.body?.includes(COMMENT_TITLE(projectName)) ||
+      // backwards compatibility for comments that don't include the project name
+      // TODO: remove this fallback eventually
+      (!comment.body?.includes(COMMENT_TITLE(null) + " for") &&
+        comment.body?.includes(COMMENT_TITLE(null))),
+  );
 
   if (!existingComment) {
     return null;

--- a/src/merge.run.ts
+++ b/src/merge.run.ts
@@ -117,7 +117,7 @@ export async function runMerge(
   }
 
   const comment =
-    makeComment && prNumber ? await retrieveComment(prNumber) : null;
+    makeComment && prNumber ? await retrieveComment(prNumber, projectName) : null;
   const commitMessage =
     comment?.commitMessage ??
     makeCommitMessageConventional(defaultCommitMessage);

--- a/src/merge.run.ts
+++ b/src/merge.run.ts
@@ -117,7 +117,9 @@ export async function runMerge(
   }
 
   const comment =
-    makeComment && prNumber ? await retrieveComment(prNumber, projectName) : null;
+    makeComment && prNumber
+      ? await retrieveComment(prNumber, projectName)
+      : null;
   const commitMessage =
     comment?.commitMessage ??
     makeCommitMessageConventional(defaultCommitMessage);

--- a/src/preview.run.ts
+++ b/src/preview.run.ts
@@ -163,7 +163,9 @@ export async function runPreview(
 
   logger.groupEnd();
 
-  const initialComment = makeComment ? await retrieveComment(prNumber, projectName) : null;
+  const initialComment = makeComment
+    ? await retrieveComment(prNumber, projectName)
+    : null;
   let commitMessage =
     initialComment?.commitMessage ??
     makeCommitMessageConventional(defaultCommitMessage);

--- a/src/preview.run.ts
+++ b/src/preview.run.ts
@@ -139,7 +139,7 @@ export async function runPreview(
     if (makeComment) {
       logger.group("Updating comment");
 
-      const commentBody = printComment({ noChanges: true });
+      const commentBody = printComment({ noChanges: true, projectName });
 
       await upsertComment(prNumber, {
         body: commentBody,
@@ -163,7 +163,7 @@ export async function runPreview(
 
   logger.groupEnd();
 
-  const initialComment = makeComment ? await retrieveComment(prNumber) : null;
+  const initialComment = makeComment ? await retrieveComment(prNumber, projectName) : null;
   let commitMessage =
     initialComment?.commitMessage ??
     makeCommitMessageConventional(defaultCommitMessage);
@@ -215,7 +215,7 @@ export async function runPreview(
       const { outcomes, baseOutcomes } = latestRun;
 
       // In case the comment was updated between polls:
-      const comment = await retrieveComment(prNumber);
+      const comment = await retrieveComment(prNumber, projectName);
       commitMessage = comment?.commitMessage ?? commitMessage;
       targetCommitMessages =
         comment?.targetCommitMessages ?? targetCommitMessages;


### PR DESCRIPTION
stick the project name in the comment title to make it easier to identify the comment from a particular project, in the case where a single source repo supports multiple projects